### PR TITLE
feat: vue support 🎉

### DIFF
--- a/.changeset/dirty-wasps-melt.md
+++ b/.changeset/dirty-wasps-melt.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+For `*.svelte` files imports from 'svelte' will not longer result in `svelte` being added as a dependency.

--- a/.changeset/dirty-wasps-melt.md
+++ b/.changeset/dirty-wasps-melt.md
@@ -2,4 +2,4 @@
 "jsrepo": patch
 ---
 
-For `*.svelte` files imports from 'svelte' will not longer result in `svelte` being added as a dependency.
+When `*.svelte` files import 'svelte' it will not longer result in `svelte` being added as a dependency.

--- a/.changeset/hip-turtles-design.md
+++ b/.changeset/hip-turtles-design.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+**vue** support! 🎉

--- a/.changeset/red-bottles-worry.md
+++ b/.changeset/red-bottles-worry.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Add `--exclude-deps` flag to `build`. This allows you to prevent certain dependencies from being added during the build.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,10 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/jsrepo"
 	},
-	"keywords": [
-		"repo",
-		"cli"
-	],
+	"keywords": ["repo", "cli"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {
@@ -48,6 +45,7 @@
 	},
 	"dependencies": {
 		"@clack/prompts": "^0.8.1",
+		"@vue/compiler-sfc": "^3.5.13",
 		"ansi-regex": "^6.1.0",
 		"chalk": "^5.3.0",
 		"commander": "^12.1.0",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -11,6 +11,7 @@ import { intro } from '../utils/prompts';
 
 const schema = v.object({
 	dirs: v.array(v.string()),
+	excludeDeps: v.array(v.string()),
 	output: v.boolean(),
 	verbose: v.boolean(),
 	cwd: v.string(),
@@ -21,6 +22,7 @@ type Options = v.InferInput<typeof schema>;
 const build = new Command('build')
 	.description(`Builds the provided --dirs in the project root into a \`${OUTPUT_FILE}\` file.`)
 	.option('--dirs [dirs...]', 'The directories containing the blocks.', ['./blocks'])
+	.option('--exclude-deps [deps...]', 'Dependencies that should not be added.', [])
 	.option('--no-output', `Do not output a \`${OUTPUT_FILE}\` file.`)
 	.option('--verbose', 'Include debug logs.', false)
 	.option('--cwd <path>', 'The current working directory.', process.cwd())
@@ -48,7 +50,9 @@ const _build = async (options: Options) => {
 
 		if (options.output && fs.existsSync(outFile)) fs.rmSync(outFile);
 
-		categories.push(...buildBlocksDirectory(dirPath, options.cwd));
+		categories.push(
+			...buildBlocksDirectory(dirPath, { cwd: options.cwd, excludeDeps: options.excludeDeps })
+		);
 
 		loading.stop(`Built ${color.cyan(dirPath)}`);
 	}

--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -33,12 +33,17 @@ const TEST_SUFFIXES = ['.test.ts', '_test.ts', '.test.js', '_test.js'] as const;
 const isTestFile = (file: string): boolean =>
 	TEST_SUFFIXES.find((suffix) => file.endsWith(suffix)) !== undefined;
 
+type Options = {
+	cwd: string;
+	excludeDeps: string[];
+};
+
 /** Using the provided path to the blocks folder builds the blocks into categories and also resolves dependencies
  *
  * @param blocksPath
  * @returns
  */
-const buildBlocksDirectory = (blocksPath: string, cwd: string): Category[] => {
+const buildBlocksDirectory = (blocksPath: string, { cwd, excludeDeps }: Options): Category[] => {
 	let paths: string[];
 
 	try {
@@ -88,7 +93,12 @@ const buildBlocksDirectory = (blocksPath: string, cwd: string): Category[] => {
 				);
 
 				const { dependencies, devDependencies, local } = lang
-					.resolveDependencies(blockDir, categoryName, false)
+					.resolveDependencies({
+						filePath: blockDir,
+						category: categoryName,
+						isSubDir: false,
+						excludeDeps,
+					})
 					.match(
 						(val) => val,
 						(err) => {
@@ -140,7 +150,12 @@ const buildBlocksDirectory = (blocksPath: string, cwd: string): Category[] => {
 					}
 
 					const { local, dependencies, devDependencies } = lang
-						.resolveDependencies(path.join(blockDir, f), categoryName, true)
+						.resolveDependencies({
+							filePath: path.join(blockDir, f),
+							category: categoryName,
+							isSubDir: true,
+							excludeDeps,
+						})
 						.match(
 							(val) => val,
 							(err) => {

--- a/packages/cli/src/utils/language-support.ts
+++ b/packages/cli/src/utils/language-support.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { builtinModules } from 'node:module';
 import path from 'node:path';
+import * as v from '@vue/compiler-sfc';
 import color from 'chalk';
 import { walk } from 'estree-walker';
 import * as sv from 'svelte/compiler';
@@ -106,7 +107,51 @@ const svelte: Lang = {
 			},
 		});
 
-		const { devDependencies, dependencies } = resolveRemoteDeps(Array.from(deps), filePath);
+		const { devDependencies, dependencies } = resolveRemoteDeps(Array.from(deps), filePath, [
+			'svelte',
+		]);
+
+		return Ok({
+			dependencies,
+			devDependencies,
+			local: Array.from(localDeps),
+		} satisfies ResolvedDependencies);
+	},
+	comment: (content) => `<!--\n${content}\n-->`,
+};
+
+const vue: Lang = {
+	matches: (fileName) => fileName.endsWith('.vue'),
+	resolveDependencies: (filePath, category, isSubDir) => {
+		const sourceCode = fs.readFileSync(filePath).toString();
+
+		const parsed = v.parse(sourceCode);
+
+		if (!parsed.descriptor.script?.content && !parsed.descriptor.scriptSetup?.content)
+			return Ok({ dependencies: [], devDependencies: [], local: [] });
+
+		const localDeps = new Set<string>();
+		const deps = new Set<string>();
+
+		const compiled = v.compileScript(parsed.descriptor, { id: 'shut-it' }); // you need this id to remove a warning
+
+		if (!compiled.imports) return Ok({ dependencies: [], devDependencies: [], local: [] });
+
+		const imports = Object.values(compiled.imports);
+
+		for (const imp of imports) {
+			if (imp.source.startsWith('.')) {
+				const localDep = resolveLocalImport(imp.source, category, isSubDir);
+
+				if (localDep) localDeps.add(localDep);
+			} else {
+				deps.add(imp.source);
+			}
+		}
+
+		const { devDependencies, dependencies } = resolveRemoteDeps(Array.from(deps), filePath, [
+			'vue',
+		]);
 
 		return Ok({
 			dependencies,
@@ -136,7 +181,7 @@ const resolveLocalImport = (
 	const segments = mod.replaceAll('../', '').split('/');
 
 	// invalid path
-	if (segments.length !== 2) return undefined;
+	if (segments.length < 2) return undefined;
 
 	return `${segments[0]}/${segments[1]}`;
 };
@@ -148,7 +193,9 @@ const resolveLocalImport = (
  * @param filePath
  * @returns
  */
-const resolveRemoteDeps = (deps: string[], filePath: string) => {
+const resolveRemoteDeps = (deps: string[], filePath: string, doNotInstall: string[] = []) => {
+	const exemptDeps = new Set(doNotInstall);
+
 	const filteredDeps = deps.filter(
 		(dep) => !builtinModules.includes(dep) && !dep.startsWith('node:')
 	);
@@ -181,6 +228,8 @@ const resolveRemoteDeps = (deps: string[], filePath: string) => {
 				continue;
 			}
 
+			if (exemptDeps.has(depInfo.name)) continue;
+
 			let version: string | undefined = undefined;
 			if (packageDependencies !== undefined) {
 				version = packageDependencies[depInfo.name];
@@ -211,6 +260,6 @@ const resolveRemoteDeps = (deps: string[], filePath: string) => {
 	};
 };
 
-const languages: Lang[] = [typescript, svelte];
+const languages: Lang[] = [typescript, svelte, vue];
 
 export { typescript, languages };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,36 +15,14 @@ importers:
         specifier: ^0.0.30
         version: 0.0.30
 
-  examples/project:
-    devDependencies:
-      jsrepo:
-        specifier: ^1.2.4
-        version: 1.2.4(typescript@5.6.3)
-      tsup:
-        specifier: ^8.3.5
-        version: 8.3.5(jiti@1.21.6)(postcss@8.4.49)(typescript@5.6.3)(yaml@2.6.0)
-      typescript:
-        specifier: ^5.6.3
-        version: 5.6.3
-
-  examples/registry:
-    dependencies:
-      chalk:
-        specifier: ^5.3.0
-        version: 5.3.0
-    devDependencies:
-      jsrepo:
-        specifier: ^1.2.4
-        version: 1.2.4(typescript@5.6.3)
-      vitest:
-        specifier: ^2.1.5
-        version: 2.1.5(@types/node@22.9.0)
-
   packages/cli:
     dependencies:
       '@clack/prompts':
         specifier: ^0.8.1
         version: 0.8.1
+      '@vue/compiler-sfc':
+        specifier: ^3.5.13
+        version: 3.5.13
       ansi-regex:
         specifier: ^6.1.0
         version: 6.1.0
@@ -216,8 +194,25 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.26.2':
+    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.26.0':
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.26.0':
+    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@1.9.4':
@@ -1229,6 +1224,21 @@ packages:
   '@vitest/utils@2.1.5':
     resolution: {integrity: sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==}
 
+  '@vue/compiler-core@3.5.13':
+    resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
+
+  '@vue/compiler-dom@3.5.13':
+    resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
+
+  '@vue/compiler-sfc@3.5.13':
+    resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
+
+  '@vue/compiler-ssr@3.5.13':
+    resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
+
+  '@vue/shared@3.5.13':
+    resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1533,6 +1543,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   es-module-lexer@1.5.4:
     resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
 
@@ -1632,6 +1646,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -1903,10 +1920,6 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
-
-  jsrepo@1.2.4:
-    resolution: {integrity: sha512-4yKZiUJRNwi+GLjm2aJCfji8wtVe0O/hV0QcvuMrnVS2QzY1bdn1x+CBIDx57AU2zOtVkoXUrdUNIiTwm3iqwg==}
-    hasBin: true
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2903,9 +2916,22 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@babel/helper-string-parser@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/parser@7.26.2':
+    dependencies:
+      '@babel/types': 7.26.0
+
   '@babel/runtime@7.26.0':
     dependencies:
       regenerator-runtime: 0.14.1
+
+  '@babel/types@7.26.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@biomejs/biome@1.9.4':
     optionalDependencies:
@@ -3900,6 +3926,38 @@ snapshots:
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
+  '@vue/compiler-core@3.5.13':
+    dependencies:
+      '@babel/parser': 7.26.2
+      '@vue/shared': 3.5.13
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.13':
+    dependencies:
+      '@vue/compiler-core': 3.5.13
+      '@vue/shared': 3.5.13
+
+  '@vue/compiler-sfc@3.5.13':
+    dependencies:
+      '@babel/parser': 7.26.2
+      '@vue/compiler-core': 3.5.13
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-ssr': 3.5.13
+      '@vue/shared': 3.5.13
+      estree-walker: 2.0.2
+      magic-string: 0.30.13
+      postcss: 8.4.49
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.13':
+    dependencies:
+      '@vue/compiler-dom': 3.5.13
+      '@vue/shared': 3.5.13
+
+  '@vue/shared@3.5.13': {}
+
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:
       acorn: 8.14.0
@@ -4145,6 +4203,8 @@ snapshots:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
 
+  entities@4.5.0: {}
+
   es-module-lexer@1.5.4: {}
 
   esbuild@0.21.5:
@@ -4317,6 +4377,8 @@ snapshots:
       estraverse: 5.3.0
 
   estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -4582,24 +4644,6 @@ snapshots:
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
-
-  jsrepo@1.2.4(typescript@5.6.3):
-    dependencies:
-      '@clack/prompts': 0.8.1
-      ansi-regex: 6.1.0
-      chalk: 5.3.0
-      commander: 12.1.0
-      diff: 7.0.0
-      estree-walker: 3.0.3
-      execa: 9.5.1
-      octokit: 4.0.2
-      package-manager-detector: 0.2.4
-      svelte: 5.2.3
-      ts-morph: 24.0.0
-      valibot: 0.42.1(typescript@5.6.3)
-      validate-npm-package-name: 6.0.0
-    transitivePeerDependencies:
-      - typescript
 
   keyv@4.5.4:
     dependencies:

--- a/sites/docs/src/routes/docs/cli/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/+page.svelte
@@ -88,11 +88,12 @@ Options:
 Builds the provided --dirs in the project root into a \`jsrepo-manifest.json\` file.
 
 Options:
-  --dirs [dirs...]  The directories containing the blocks. (default: ["./blocks"])
-  --no-output       Do not output a \`jsrepo-manifest.json\` file.
-  --verbose         Include debug logs. (default: false)
-  --cwd <path>      The current working directory. (default: ".")
-  -h, --help        display help for command`}
+  --dirs [dirs...]          The directories containing the blocks. (default: ["./blocks"])
+  --exclude-deps [deps...]  Dependencies that should not be added. (default: [])
+  --no-output               Do not output a \`jsrepo-manifest.json\` file.
+  --verbose                 Include debug logs. (default: false)
+  --cwd <path>              The current working directory. (default: ".")
+  -h, --help                display help for command`}
 />
 <SubHeading>test</SubHeading>
 <p>

--- a/sites/docs/src/routes/docs/language-support/+page.svelte
+++ b/sites/docs/src/routes/docs/language-support/+page.svelte
@@ -39,7 +39,7 @@
 		{
 			logo: vue,
 			name: '*.vue',
-			status: '🚫'
+			status: '✅'
 		}
 	];
 </script>


### PR DESCRIPTION
- Adds support for `*.vue` files.
- Exempts `svelte` and `vue` from being added as dependencies of `*.svelte` and `*.vue` files. I think we can safely assume anyone installing those files should already have those installed.
- Adds `--exclude-deps` flag to the `build` command. This allows you to prevent certain dependencies from being added to the manifest. This is nice when you have a library that uses `next` or something and want to make sure `next` isn't installed when others bring your code into their next project.