### PR TITLE
chore: Use `pathe` instead of `node:path` 

### DIFF
--- a/.changeset/soft-chicken-yawn.md
+++ b/.changeset/soft-chicken-yawn.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Use `pathe` instead of `node:path`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,10 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/jsrepo"
 	},
-	"keywords": [
-		"repo",
-		"cli"
-	],
+	"keywords": ["repo", "cli"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {
@@ -57,6 +54,7 @@
 		"execa": "^9.5.1",
 		"octokit": "^4.0.2",
 		"package-manager-detector": "^0.2.4",
+		"pathe": "^1.1.2",
 		"svelte": "^5.2.3",
 		"ts-morph": "^24.0.0",
 		"valibot": "^0.42.1",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,10 +1,10 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { cancel, confirm, isCancel, multiselect, outro, spinner } from '@clack/prompts';
 import color from 'chalk';
 import { Command, program } from 'commander';
 import { resolveCommand } from 'package-manager-detector/commands';
 import { detect } from 'package-manager-detector/detect';
+import path from 'pathe';
 import * as v from 'valibot';
 import { context } from '..';
 import * as ascii from '../utils/ascii';

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { outro, spinner } from '@clack/prompts';
 import color from 'chalk';
 import { Command } from 'commander';
+import path from 'pathe';
 import * as v from 'valibot';
 import { context } from '..';
 import { type Category, buildBlocksDirectory } from '../utils/build';

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { cancel, confirm, isCancel, outro, spinner } from '@clack/prompts';
 import color from 'chalk';
 import { Command, program } from 'commander';
 import { diffLines } from 'diff';
+import path from 'pathe';
 import * as v from 'valibot';
 import { context } from '..';
 import * as ascii from '../utils/ascii';
@@ -156,18 +156,14 @@ const _diff = async (options: Options) => {
 
 				const changes = diffLines(fileContent, remoteContent);
 
-				const from = path
-					.join(
-						`${providerInfo.name}/${providerInfo.owner}/${providerInfo.repoName}`,
-						sourcePath
-					)
-					.replaceAll('\\', '/');
-
-				const to = prettyLocalPath.replaceAll('\\', '/');
+				const from = path.join(
+					`${providerInfo.name}/${providerInfo.owner}/${providerInfo.repoName}`,
+					sourcePath
+				);
 
 				const formattedDiff = formatDiff({
 					from,
-					to,
+					to: prettyLocalPath,
 					changes,
 					expand: options.expand,
 					maxUnchanged: options.maxUnchanged,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { cancel, confirm, isCancel, outro, spinner, text } from '@clack/prompts';
 import color from 'chalk';
 import { Command } from 'commander';
+import path from 'pathe';
 import * as v from 'valibot';
 import { context } from '..';
 import { CONFIG_NAME, type Config, getConfig } from '../utils/config';

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { cancel, confirm, isCancel, outro, spinner } from '@clack/prompts';
 import color from 'chalk';
 import { Argument, Command, program } from 'commander';
 import { execa } from 'execa';
 import { resolveCommand } from 'package-manager-detector/commands';
 import { detect } from 'package-manager-detector/detect';
+import path from 'pathe';
 import { Project } from 'ts-morph';
 import * as v from 'valibot';
 import { context } from '..';

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { cancel, confirm, isCancel, multiselect, outro, spinner } from '@clack/prompts';
 import color from 'chalk';
 import { Command, program } from 'commander';
 import { diffLines } from 'diff';
 import { resolveCommand } from 'package-manager-detector/commands';
 import { detect } from 'package-manager-detector/detect';
+import path from 'pathe';
 import * as v from 'valibot';
 import { context } from '..';
 import * as ascii from '../utils/ascii';
@@ -239,14 +239,12 @@ const _update = async (blockNames: string[], options: Options) => {
 
 				const changes = diffLines(localContent, remoteContent);
 
-				const from = path
-					.join(
-						`${providerInfo.name}/${providerInfo.owner}/${providerInfo.repoName}`,
-						file.fileName
-					)
-					.replaceAll('\\', '/');
+				const from = path.join(
+					`${providerInfo.name}/${providerInfo.owner}/${providerInfo.repoName}`,
+					file.fileName
+				);
 
-				const to = path.relative(options.cwd, file.destPath).replaceAll('\\', '/');
+				const to = path.relative(options.cwd, file.destPath);
 
 				const formattedDiff = formatDiff({
 					from,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { program } from 'commander';
+import path from 'pathe';
 import * as commands from './commands';
 import type { CLIContext } from './utils/context';
 

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import color from 'chalk';
+import path from 'pathe';
 import { Err, Ok, type Result } from './blocks/types/result';
 import { mapToArray } from './blocks/utils/map-to-array';
 import type { Block } from './build';

--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import color from 'chalk';
 import { program } from 'commander';
+import path from 'pathe';
 import * as v from 'valibot';
 import * as ascii from './ascii';
 import { languages } from './language-support';

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import path from 'node:path';
+import path from 'pathe';
 import * as v from 'valibot';
 import { Err, Ok, type Result } from './blocks/types/result';
 

--- a/packages/cli/src/utils/language-support.ts
+++ b/packages/cli/src/utils/language-support.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 import { builtinModules } from 'node:module';
-import path from 'node:path';
 import * as v from '@vue/compiler-sfc';
 import color from 'chalk';
 import { walk } from 'estree-walker';
+import path from 'pathe';
 import * as sv from 'svelte/compiler';
 import { Project } from 'ts-morph';
 import validatePackageName from 'validate-npm-package-name';

--- a/packages/cli/src/utils/package.ts
+++ b/packages/cli/src/utils/package.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import path from 'node:path';
+import path from 'pathe';
 
 const findNearestPackageJson = (startDir: string, until: string): string | undefined => {
 	const packagePath = path.join(startDir, 'package.json');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       package-manager-detector:
         specifier: ^0.2.4
         version: 0.2.4
+      pathe:
+        specifier: ^1.1.2
+        version: 1.1.2
       svelte:
         specifier: ^5.2.3
         version: 5.2.3


### PR DESCRIPTION
Should make the experience more pleasant for any unfortunate windows users like myself.