### PR TITLE
feat: `build` flags `--include-blocks` and `--include-categories`

### DIFF
--- a/.changeset/stale-buttons-cross.md
+++ b/.changeset/stale-buttons-cross.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Add `--include-blocks` and `--include-categories` flags to `build` command. These allow you to only include the provided blocks or categories in the build.

--- a/.changeset/tough-apples-attend.md
+++ b/.changeset/tough-apples-attend.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Add `error-on-warn` flag so that you can choose to error on warnings during build.

--- a/.changeset/tricky-files-taste.md
+++ b/.changeset/tricky-files-taste.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+jsrepo now checks the manifest file before writing it to warn about potential issues.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,10 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/jsrepo"
 	},
-	"keywords": [
-		"repo",
-		"cli"
-	],
+	"keywords": ["repo", "cli"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {

--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -38,6 +38,7 @@ type Options = {
 	excludeDeps: string[];
 	includeBlocks: string[];
 	includeCategories: string[];
+	errorOnWarn: boolean;
 };
 
 /** Using the provided path to the blocks folder builds the blocks into categories and also resolves dependencies
@@ -47,7 +48,7 @@ type Options = {
  */
 const buildBlocksDirectory = (
 	blocksPath: string,
-	{ cwd, excludeDeps, includeBlocks, includeCategories }: Options
+	{ cwd, excludeDeps, includeBlocks, includeCategories, errorOnWarn }: Options
 ): Category[] => {
 	let paths: string[];
 
@@ -98,11 +99,24 @@ const buildBlocksDirectory = (
 				const lang = languages.find((resolver) => resolver.matches(file));
 
 				if (!lang) {
-					console.warn(
-						`${ascii.WARN} Skipped \`${color.bold(blockDir)}\` \`${color.bold(
-							path.parse(file).ext
-						)}\` files are not currently supported!`
-					);
+					const error = 'files are not currently supported!';
+
+					if (errorOnWarn) {
+						program.error(
+							color.red(
+								`Couldn't add \`${color.bold(blockDir)}\` \`${color.bold(
+									path.parse(file).ext
+								)}\` ${error}`
+							)
+						);
+					} else {
+						console.warn(
+							`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(blockDir)}\` \`${color.bold(
+								path.parse(file).ext
+							)}\` ${error}`
+						);
+					}
+
 					continue;
 				}
 
@@ -165,20 +179,42 @@ const buildBlocksDirectory = (
 					if (isTestFile(f)) continue;
 
 					if (fs.statSync(path.join(blockDir, f)).isDirectory()) {
-						console.warn(
-							`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(path.join(blockDir, f))}\` subdirectories are not currently supported!`
-						);
+						const error = 'subdirectories are not currently supported!';
+
+						if (errorOnWarn) {
+							program.error(
+								color.red(
+									`Couldn't add \`${color.bold(path.join(blockDir, f))}\` ${error}`
+								)
+							);
+						} else {
+							console.warn(
+								`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(path.join(blockDir, f))}\` ${error}`
+							);
+						}
 						continue;
 					}
 
 					const lang = languages.find((resolver) => resolver.matches(f));
 
 					if (!lang) {
-						console.warn(
-							`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(path.join(blockDir, f))}\` \`*${color.bold(
-								path.parse(f).ext
-							)}\` files are not currently supported!`
-						);
+						const error = 'files are not currently supported!';
+
+						if (errorOnWarn) {
+							program.error(
+								color.red(
+									`Couldn't add \`${color.bold(path.join(blockDir, f))}\` \`${color.bold(
+										path.parse(f).ext
+									)}\` ${error}`
+								)
+							);
+						} else {
+							console.warn(
+								`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${path.join(blockDir, f)}\` \`${color.bold(
+									path.parse(f).ext
+								)}\` ${error}`
+							);
+						}
 						continue;
 					}
 

--- a/packages/cli/src/utils/build.ts
+++ b/packages/cli/src/utils/build.ts
@@ -104,14 +104,14 @@ const buildBlocksDirectory = (
 					if (errorOnWarn) {
 						program.error(
 							color.red(
-								`Couldn't add \`${color.bold(blockDir)}\` \`${color.bold(
+								`Couldn't add \`${color.bold(blockDir)}\` \`*${color.bold(
 									path.parse(file).ext
 								)}\` ${error}`
 							)
 						);
 					} else {
 						console.warn(
-							`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(blockDir)}\` \`${color.bold(
+							`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(blockDir)}\` \`*${color.bold(
 								path.parse(file).ext
 							)}\` ${error}`
 						);
@@ -203,14 +203,14 @@ const buildBlocksDirectory = (
 						if (errorOnWarn) {
 							program.error(
 								color.red(
-									`Couldn't add \`${color.bold(path.join(blockDir, f))}\` \`${color.bold(
+									`Couldn't add \`${color.bold(path.join(blockDir, f))}\` \`*${color.bold(
 										path.parse(f).ext
 									)}\` ${error}`
 								)
 							);
 						} else {
 							console.warn(
-								`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${path.join(blockDir, f)}\` \`${color.bold(
+								`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${path.join(blockDir, f)}\` \`*${color.bold(
 									path.parse(f).ext
 								)}\` ${error}`
 							);

--- a/sites/docs/src/routes/docs/cli/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/+page.svelte
@@ -92,12 +92,15 @@ Options:
 Builds the provided --dirs in the project root into a \`jsrepo-manifest.json\` file.
 
 Options:
-  --dirs [dirs...]          The directories containing the blocks. (default: ["./blocks"])
-  --exclude-deps [deps...]  Dependencies that should not be added. (default: [])
-  --no-output               Do not output a \`jsrepo-manifest.json\` file.
-  --verbose                 Include debug logs. (default: false)
-  --cwd <path>              The current working directory. (default: ".")
-  -h, --help                display help for command`}
+  --dirs [dirs...]                         The directories containing the blocks. (default: ["./blocks"])
+  --include-blocks [blockNames...]         Include only the blocks with these names. (default: [])
+  --include-categories [categoryNames...]  Include only the categories with these names. (default: [])
+  --exclude-deps [deps...]                 Dependencies that should not be added. (default: [])
+  --no-output                              Do not output a \`jsrepo-manifest.json\` file.
+  --error-on-warn                          If there is a warning throw an error and do not allow build to complete. (default: false)
+  --verbose                                Include debug logs. (default: false)
+  --cwd <path>                             The current working directory. (default: ".")
+  -h, --help                               display help for command`}
 />
 <SubHeading>test</SubHeading>
 <p>


### PR DESCRIPTION
Fixes #145 

- Also adds `--error-on-warn` flag that will cause build to error on warnings
- jsrepo now checks your manifest file before writing it so it can warn you about dependencies to blocks that don't exist and remote dependencies that aren't using pinned versions.