### PR TITLE
feat: zero-config adds

### DIFF
--- a/.changeset/polite-suns-sleep.md
+++ b/.changeset/polite-suns-sleep.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Make `auth --logout` smarter so that it shows you if you were already logged out.

--- a/.changeset/popular-kids-behave.md
+++ b/.changeset/popular-kids-behave.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Allow for zero-config adds where users will be prompted for the options necessary to install the `block`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,10 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/jsrepo"
 	},
-	"keywords": [
-		"repo",
-		"cli"
-	],
+	"keywords": ["repo", "cli"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -3,6 +3,7 @@ import color from 'chalk';
 import { Command, Option } from 'commander';
 import * as v from 'valibot';
 import { context } from '..';
+import * as ascii from '../utils/ascii';
 import { providers } from '../utils/git-providers';
 import * as persisted from '../utils/persisted';
 import { intro } from '../utils/prompts';
@@ -41,6 +42,18 @@ const _auth = async (options: Options) => {
 
 	if (options.logout) {
 		for (const provider of providers) {
+			const tokenKey = `${provider.name()}-token`;
+
+			if (storage.get(tokenKey) === undefined) {
+				process.stdout.write(`${ascii.VERTICAL_LINE}\n`);
+				process.stdout.write(
+					color.gray(
+						`${ascii.VERTICAL_LINE}  Already logged out of ${provider.name()}.\n`
+					)
+				);
+				continue;
+			}
+
 			const response = await confirm({
 				message: `Remove ${provider.name()} token?`,
 				initialValue: true,
@@ -53,7 +66,7 @@ const _auth = async (options: Options) => {
 
 			if (!response) continue;
 
-			storage.delete(`${provider.name()}-token`);
+			storage.delete(tokenKey);
 		}
 		return;
 	}


### PR DESCRIPTION
Fixes #112 

Enables zero-config adds.

This way you can tell your users to install your code with:
```bash
npx jsrepo add github/ieedan/std/utils/math
```

And it will just work out of the box.

- Also improves `--logout` in `auth` command