### PR TITLE
feat: BitBucket support 🎉

### DIFF
--- a/.changeset/gold-lemons-juggle.md
+++ b/.changeset/gold-lemons-juggle.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+BitBucket support 🎉

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,10 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/jsrepo"
 	},
-	"keywords": [
-		"repo",
-		"cli"
-	],
+	"keywords": ["repo", "cli"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -105,7 +105,7 @@ const _add = async (blockNames: string[], options: Options) => {
 		let repo: string;
 		// if rest is greater than 2 it isn't the block specifier so it is part of the path
 		if (rest.length > 2) {
-			repo = `${providerName}/${owner}/${repoName}/${rest.join('/')}`;
+			repo = `${providerName}/${owner}/${repoName}/${rest.slice(0, rest.length - 2).join('/')}`;
 		} else {
 			repo = `${providerName}/${owner}/${repoName}`;
 		}

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -183,7 +183,7 @@ const _test = async (blockNames: string[], options: Options) => {
 				let repo: string;
 				// if rest is greater than 2 it isn't the block specifier so it is part of the path
 				if (rest.length > 2) {
-					repo = `${providerName}/${owner}/${repoName}/${rest.join('/')}`;
+					repo = `${providerName}/${owner}/${repoName}/${rest.slice(0, rest.length - 2).join('/')}`;
 				} else {
 					repo = `${providerName}/${owner}/${repoName}`;
 				}

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -53,14 +53,19 @@ const resolveTree = async (
 				break;
 			}
 		} else {
-			block = blocksMap.get(blockSpecifier);
+			// get shortened name
+			const [providerName, owner, repoName, ...rest] = blockSpecifier.split('/');
+
+			block = blocksMap.get(
+				`${providerName}/${owner}/${repoName}/${rest.slice(rest.length - 2).join('/')}`
+			);
 		}
 
 		if (!block) {
 			return Err(`Invalid block! ${color.bold(blockSpecifier)} does not exist!`);
 		}
 
-		const fullSpecifier = `${block.sourceRepo.url}/${block.category}/${block.name}`;
+		const fullSpecifier = `${block.sourceRepo.name}/${block.sourceRepo.owner}/${block.sourceRepo.repoName}/${block.category}/${block.name}`;
 
 		blocks.set(fullSpecifier, { name: fullSpecifier, subDependency: false, block });
 

--- a/packages/cli/tests/git-providers.test.ts
+++ b/packages/cli/tests/git-providers.test.ts
@@ -2,30 +2,203 @@ import { describe, expect, it } from 'vitest';
 import * as gitProviders from '../src/utils/git-providers';
 
 describe('github', () => {
-	it('Handles long form urls', async () => {
-		const url = 'https://github.com/ieedan/std/tree/main';
+	it('Fetches the manifest from a public repo', async () => {
+		const repoURL = 'github/ieedan/std';
 
-		const info = await gitProviders.github.info(url);
+		const info = await gitProviders.github.info(repoURL);
 
-		expect(info.name).toBe('github');
-		expect(info.owner).toBe('ieedan');
-		expect(info.refs).toBe('heads');
-		expect(info.ref).toBe('main');
-		expect(info.url).toBe(url);
-		expect(info.repoName).toBe('std');
+		const content = await gitProviders.github.fetchManifest(info);
+
+		expect(content.isErr()).toBe(false);
 	});
 
-	it('Handles shorthand urls', async () => {
-		const url = 'github/ieedan/std/tree/main';
+	it('Fetches the manifest from a public repo with a tag', async () => {
+		const repoURL = 'https://github.com/ieedan/std/tree/v1.6.0';
 
-		const info = await gitProviders.github.info(url);
+		const info = await gitProviders.github.info(repoURL);
 
-		expect(info.name).toBe('github');
-		expect(info.owner).toBe('ieedan');
-		expect(info.refs).toBe('heads');
-		expect(info.ref).toBe('main');
-		expect(info.url).toBe(url);
-		expect(info.repoName).toBe('std');
+		const content = await gitProviders.github.fetchRaw(info, 'jsrepo-manifest.json');
+
+		expect(content.unwrap()).toBe(`[
+	{
+		"name": "types",
+		"blocks": [
+			{
+				"name": "result",
+				"directory": "src/types",
+				"category": "types",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["result.ts", "result.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	},
+	{
+		"name": "utilities",
+		"blocks": [
+			{
+				"name": "array-sum",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["array-sum.ts", "array-sum.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "array-to-map",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["array-to-map.ts", "array-to-map.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "dispatcher",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["dispatcher.ts", "dispatcher.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "ipv4-address",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["ipv4-address.ts", "ipv4-address.test.ts"],
+				"localDependencies": ["types/result", "utilities/is-number"],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "is-number",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["is-number.ts", "is-number.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "lines",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["lines.ts", "lines.test.ts"],
+				"localDependencies": ["utilities/pad"],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "map-to-array",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["map-to-array.ts", "map-to-array.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "math",
+				"directory": "src/utilities/math",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": true,
+				"files": [
+					"circle.test.ts",
+					"circle.ts",
+					"conversions.test.ts",
+					"conversions.ts",
+					"fractions.test.ts",
+					"fractions.ts",
+					"gcf.test.ts",
+					"gcf.ts",
+					"index.ts",
+					"triangles.test.ts",
+					"triangles.ts",
+					"types.ts"
+				],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "pad",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["pad.ts", "pad.test.ts"],
+				"localDependencies": ["utilities/strip-ansi"],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "sleep",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["sleep.ts", "sleep.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "stopwatch",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["stopwatch.ts", "stopwatch.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "strip-ansi",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["strip-ansi.ts", "strip-ansi.test.ts"],
+				"localDependencies": [],
+				"dependencies": ["ansi-regex@^6.1.0"],
+				"devDependencies": []
+			},
+			{
+				"name": "truncate",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["truncate.ts", "truncate.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	}
+]
+`);
 	});
 });
 
@@ -46,6 +219,207 @@ describe('gitlab', () => {
 		const info = await gitProviders.gitlab.info(repoURL);
 
 		const content = await gitProviders.gitlab.fetchRaw(info, 'jsrepo-manifest.json');
+
+		expect(content.unwrap()).toBe(`[
+	{
+		"name": "types",
+		"blocks": [
+			{
+				"name": "result",
+				"directory": "src/types",
+				"category": "types",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["result.ts", "result.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	},
+	{
+		"name": "utilities",
+		"blocks": [
+			{
+				"name": "array-sum",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["array-sum.ts", "array-sum.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "array-to-map",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["array-to-map.ts", "array-to-map.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "dispatcher",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["dispatcher.ts", "dispatcher.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "ipv4-address",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["ipv4-address.ts", "ipv4-address.test.ts"],
+				"localDependencies": ["types/result", "utilities/is-number"],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "is-number",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["is-number.ts", "is-number.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "lines",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["lines.ts", "lines.test.ts"],
+				"localDependencies": ["utilities/pad"],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "map-to-array",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["map-to-array.ts", "map-to-array.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "math",
+				"directory": "src/utilities/math",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": true,
+				"files": [
+					"circle.test.ts",
+					"circle.ts",
+					"conversions.test.ts",
+					"conversions.ts",
+					"fractions.test.ts",
+					"fractions.ts",
+					"gcf.test.ts",
+					"gcf.ts",
+					"index.ts",
+					"triangles.test.ts",
+					"triangles.ts",
+					"types.ts"
+				],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "pad",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["pad.ts", "pad.test.ts"],
+				"localDependencies": ["utilities/strip-ansi"],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "sleep",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["sleep.ts", "sleep.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "stopwatch",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["stopwatch.ts", "stopwatch.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "strip-ansi",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["strip-ansi.ts", "strip-ansi.test.ts"],
+				"localDependencies": [],
+				"dependencies": ["ansi-regex@^6.1.0"],
+				"devDependencies": []
+			},
+			{
+				"name": "truncate",
+				"directory": "src/utilities",
+				"category": "utilities",
+				"tests": true,
+				"subdirectory": false,
+				"files": ["truncate.ts", "truncate.test.ts"],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	}
+]
+`);
+	});
+});
+
+describe('bitbucket', () => {
+	it('Fetches the manifest from a public repo', async () => {
+		const repoURL = 'bitbucket/ieedan/std/src/main';
+
+		const info = await gitProviders.bitbucket.info(repoURL);
+
+		const content = await gitProviders.bitbucket.fetchManifest(info);
+
+		expect(content.isErr()).toBe(false);
+	});
+
+	it('Fetches the manifest from a public repo with a tag', async () => {
+		const repoURL = 'https://bitbucket.org/ieedan/std/src/v1.6.0';
+
+		const info = await gitProviders.bitbucket.info(repoURL);
+
+		const content = await gitProviders.bitbucket.fetchRaw(info, 'jsrepo-manifest.json');
 
 		expect(content.unwrap()).toBe(`[
 	{

--- a/sites/docs/src/routes/docs/git-providers/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/+page.svelte
@@ -28,7 +28,7 @@
 			logo: bitbucket,
 			name: 'BitBucket',
 			href: '/docs/git-providers/bitbucket',
-			status: '⌛️'
+			status: '✅'
 		}
 	];
 </script>

--- a/sites/docs/src/routes/docs/git-providers/bitbucket/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/bitbucket/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import { DocHeader, Jsrepo, Link, SubHeading, Code } from '$lib/components/site/docs';
+	import CodeSpan from '$lib/components/site/docs/code-span.svelte';
+	import { Snippet } from '$lib/components/ui/snippet';
+
+	let { data } = $props();
+</script>
+
+<DocHeader title="BitBucket" description="How to use BitBucket as your jsrepo registry." />
+<SubHeading>Branches and Tags</SubHeading>
+<p>
+	<Jsrepo /> supports <Link target="_blank" href="https://bitbucket.org">BitBucket</Link> so that you can just
+	paste a link to the repo homepage and it will be handled correctly.
+</p>
+<p>Because of this all of the following paths work:</p>
+<Code
+	showLines={false}
+	lang="bash"
+	code={`https://bitbucket.org/ieedan/std # master shorthand
+https://bitbucket.org/ieedan/std/src/v1.5.0 # tag reference
+https://bitbucket.org/ieedan/std/src/next # branch reference
+`}
+/>
+<SubHeading>Using Tags for Versioning</SubHeading>
+<p>
+	Tags can be a great solution to ensuring remote tests and blocks stay on a consistent version.
+</p>
+<Code
+	showLines={false}
+	lang="json"
+	code={`{
+	"$schema": "https://unpkg.com/jsrepo@${data.version}/schema.json",
+    // use a specific version tag
+	"repos": ["https://bitbucket.org/ieedan/std/src/v1.5.0"],
+	"path": "src/blocks",
+	"includeTests": false,
+	"watermark": true
+}`}
+/>
+<p>
+	Tags do not however work like npm packages. Tags are completely mutable meaning a malicious
+	registry could publish over a tag with different code.
+</p>
+<p>This is why it's always important to make sure you trust the owner of the registry.</p>
+<SubHeading><CodeSpan class="text-2xl">bitbucket</CodeSpan> Shorthand</SubHeading>
+<p>
+	When referencing <Link target="_blank" href="https://bitbucket.org">bitbucket</Link> as the provider you
+	can use the <CodeSpan>bitbucket</CodeSpan> shorthand in place of
+	<CodeSpan>https://bitbucket.org</CodeSpan>.
+</p>
+<p>Example:</p>
+<Snippet command="execute" args={['jsrepo', 'add', 'bitbucket/ieedan/src/main/std/utils/math']} />
+<p>
+	In the <CodeSpan>jsrepo.json</CodeSpan>:
+</p>
+<Code
+	lang="json"
+	code={`{
+	"$schema": "https://unpkg.com/jsrepo@${data.version}/schema.json",
+    // use bitbucket instead of https://bitbucket.org
+	"repos": ["bitbucket/ieedan/std/src/main"],
+	"path": "src/blocks",
+	"includeTests": false,
+	"watermark": true
+}`}
+/>

--- a/sites/docs/src/routes/docs/git-providers/bitbucket/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/bitbucket/+page.svelte
@@ -9,8 +9,8 @@
 <DocHeader title="BitBucket" description="How to use BitBucket as your jsrepo registry." />
 <SubHeading>Branches and Tags</SubHeading>
 <p>
-	<Jsrepo /> supports <Link target="_blank" href="https://bitbucket.org">BitBucket</Link> so that you can just
-	paste a link to the repo homepage and it will be handled correctly.
+	<Jsrepo /> supports <Link target="_blank" href="https://bitbucket.org">BitBucket</Link> so that you
+	can just paste a link to the repo homepage and it will be handled correctly.
 </p>
 <p>Because of this all of the following paths work:</p>
 <Code
@@ -44,12 +44,12 @@ https://bitbucket.org/ieedan/std/src/next # branch reference
 <p>This is why it's always important to make sure you trust the owner of the registry.</p>
 <SubHeading><CodeSpan class="text-2xl">bitbucket</CodeSpan> Shorthand</SubHeading>
 <p>
-	When referencing <Link target="_blank" href="https://bitbucket.org">bitbucket</Link> as the provider you
-	can use the <CodeSpan>bitbucket</CodeSpan> shorthand in place of
+	When referencing <Link target="_blank" href="https://bitbucket.org">bitbucket</Link> as the provider
+	you can use the <CodeSpan>bitbucket</CodeSpan> shorthand in place of
 	<CodeSpan>https://bitbucket.org</CodeSpan>.
 </p>
 <p>Example:</p>
-<Snippet command="execute" args={['jsrepo', 'add', 'bitbucket/ieedan/src/main/std/utils/math']} />
+<Snippet command="execute" args={['jsrepo', 'add', 'bitbucket/ieedan/std/src/main/utils/math']} />
 <p>
 	In the <CodeSpan>jsrepo.json</CodeSpan>:
 </p>

--- a/sites/docs/src/routes/docs/private-repositories/+page.svelte
+++ b/sites/docs/src/routes/docs/private-repositories/+page.svelte
@@ -64,12 +64,8 @@
 						<CodeSpan>read_repository</CodeSpan>.
 					</li>
 					<li>
-						- <Link
-							target="_blank"
-							href="https://bitbucket.org"
-						>
-							BitBucket
-						</Link> - Create an access token with <CodeSpan>Read</CodeSpan> for
+						- <Link target="_blank" href="https://bitbucket.org">BitBucket</Link> - Create an access
+						token with <CodeSpan>Read</CodeSpan> for
 						<CodeSpan>Repositories</CodeSpan>.
 					</li>
 				</ul>

--- a/sites/docs/src/routes/docs/private-repositories/+page.svelte
+++ b/sites/docs/src/routes/docs/private-repositories/+page.svelte
@@ -63,6 +63,15 @@
 						</Link> - Create an access token with <CodeSpan>read_api</CodeSpan> and
 						<CodeSpan>read_repository</CodeSpan>.
 					</li>
+					<li>
+						- <Link
+							target="_blank"
+							href="https://bitbucket.org"
+						>
+							BitBucket
+						</Link> - Create an access token with <CodeSpan>Read</CodeSpan> for
+						<CodeSpan>Repositories</CodeSpan>.
+					</li>
 				</ul>
 			</Accordion.Content>
 		</Accordion.Item>

--- a/sites/docs/src/routes/docs/setup/registry/+page.svelte
+++ b/sites/docs/src/routes/docs/setup/registry/+page.svelte
@@ -236,5 +236,8 @@ const add = (a: number, b: number): number => {
 		<li class="list-disc">
 			<Link target="_blank" href="https://gitlab.com/ieedan/std">gitlab/ieedan/std</Link>
 		</li>
+		<li class="list-disc">
+			<Link target="_blank" href="https://bitbucket.org/ieedan/std">bitbucket/ieedan/std</Link>
+		</li>
 	</ul>
 </div>

--- a/sites/docs/src/routes/docs/setup/registry/+page.svelte
+++ b/sites/docs/src/routes/docs/setup/registry/+page.svelte
@@ -8,8 +8,9 @@
 <DocHeader title="Registry Setup" description="Create your own registry to share your code." />
 <p>
 	To create a registry start by creating a new
-	<Link target="_blank" href="https://github.com/new">github</Link>
-	or <Link target="_blank" href="https://gitlab.com/projects/new#blank_project">gitlab</Link> repository.
+	<Link target="_blank" href="https://github.com/new">GitHub</Link>,
+	<Link target="_blank" href="https://gitlab.com/projects/new#blank_project">GitLab</Link>, or
+	<Link target="_blank" href="https://bitbucket.org">BitBucket</Link> repository.
 </p>
 <p>
 	<Jsrepo /> looks at the directories in your project to determine which blocks to add the the


### PR DESCRIPTION
Fixes #163 

Adds full bit bucket support including tags and branches. Private repositories *should* work I am using the Bearer scheme like there is in the docs but if there are any paying users that would like to test that for me please do!

## TODO
- [x] Add `/git-providers/bitbucket`
- [x] Add FAQ for bitbucket
- [x] Add documentation for what the default branches are (github: main, gitlab: main, bitbucket: master)