### PR TITLE
fix: Check `package.json` before installing dependencies

### DIFF
--- a/.changeset/rude-tools-trade.md
+++ b/.changeset/rude-tools-trade.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Checks package.json for dependencies before trying to install the same dependency on `update` and `add`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,10 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/jsrepo"
 	},
-	"keywords": [
-		"repo",
-		"cli"
-	],
+	"keywords": ["repo", "cli"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -15,6 +15,7 @@ import { installDependencies } from '../utils/dependencies';
 import { getWatermark } from '../utils/get-watermark';
 import * as gitProviders from '../utils/git-providers';
 import { languages } from '../utils/language-support';
+import { returnShouldInstall } from '../utils/package';
 import { type Task, intro, nextSteps, runTasks } from '../utils/prompts';
 
 const schema = v.object({
@@ -143,14 +144,18 @@ const _add = async (blockNames: string[], options: Options) => {
 		if (noConfig) {
 			program.error(
 				color.red(
-					`Fully quality blocks ex: (github/ieedan/std/utils/math) or provide the \`${color.bold('--repo')}\` flag to specify a registry.`
+					`Fully quality blocks ex: (github/ieedan/std/utils/math) or provide the \`${color.bold(
+						'--repo'
+					)}\` flag to specify a registry.`
 				)
 			);
 		}
 
 		program.error(
 			color.red(
-				`There were no repos present in your config and you didn't provide the \`${color.bold('--repo')}\` flag with a repo.`
+				`There were no repos present in your config and you didn't provide the \`${color.bold(
+					'--repo'
+				)}\` flag with a repo.`
 			)
 		);
 	}
@@ -231,8 +236,8 @@ const _add = async (blockNames: string[], options: Options) => {
 
 	const tasks: Task[] = [];
 
-	const devDeps: Set<string> = new Set<string>();
-	const deps: Set<string> = new Set<string>();
+	let devDeps: Set<string> = new Set<string>();
+	let deps: Set<string> = new Set<string>();
 
 	if (noConfig) {
 		const blocksPath = await text({
@@ -389,6 +394,12 @@ const _add = async (blockNames: string[], options: Options) => {
 	}
 
 	await runTasks(tasks, { verbose: options.verbose ? verbose : undefined });
+
+	// check if dependencies are already installed
+	const requiredDependencies = returnShouldInstall(deps, devDeps, { cwd: options.cwd });
+
+	deps = requiredDependencies.dependencies;
+	devDeps = requiredDependencies.devDependencies;
 
 	const hasDependencies = deps.size > 0 || devDeps.size > 0;
 

--- a/packages/cli/src/utils/package.ts
+++ b/packages/cli/src/utils/package.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'pathe';
+import { Err, Ok, type Result } from './blocks/types/result';
 
 const findNearestPackageJson = (startDir: string, until: string): string | undefined => {
 	const packagePath = path.join(startDir, 'package.json');
@@ -13,4 +14,71 @@ const findNearestPackageJson = (startDir: string, until: string): string | undef
 	return findNearestPackageJson(segments.slice(0, segments.length - 1).join('/'), until);
 };
 
-export { findNearestPackageJson };
+type PackageJson = {
+	name: string;
+	version: string;
+	description: string;
+	scripts: Record<string, string>;
+	dependencies: Record<string, string>;
+	devDependencies: Record<string, string>;
+};
+
+const getPackage = (path: string): Result<Partial<PackageJson>, string> => {
+	if (!fs.existsSync(path)) return Err(`${path} doesn't exist`);
+
+	const contents = fs.readFileSync(path).toString();
+
+	return Ok(JSON.parse(contents));
+};
+
+const returnShouldInstall = (
+	dependencies: Set<string>,
+	devDependencies: Set<string>,
+	{ cwd }: { cwd: string }
+): { devDependencies: Set<string>; dependencies: Set<string> } => {
+	// don't mutate originals
+	const tempDeps = dependencies;
+	const tempDevDeps = devDependencies;
+
+	const packageResult = getPackage(path.join(cwd, 'package.json'));
+
+	if (!packageResult.isErr()) {
+		const pkg = packageResult.unwrap();
+
+		if (pkg.dependencies) {
+			for (const dep of tempDeps) {
+				const [name, version] = dep.split('@');
+
+				const foundDep = pkg.dependencies[name];
+
+				// if the version isn't pinned then no need to delete
+				if (version === undefined && foundDep) continue;
+
+				// if the version installed is the same as the requested version remove the dep
+				if (foundDep && foundDep === version) {
+					tempDeps.delete(dep);
+				}
+			}
+		}
+
+		if (pkg.devDependencies) {
+			for (const dep of tempDevDeps) {
+				const [name, version] = dep.split('@');
+
+				const foundDep = pkg.devDependencies[name];
+
+				// if the version isn't pinned then no need to delete
+				if (version === undefined && foundDep) continue;
+
+				// if the version installed is the same as the requested version remove the dep
+				if (foundDep && foundDep === version) {
+					tempDevDeps.delete(dep);
+				}
+			}
+		}
+	}
+
+	return { dependencies: tempDeps, devDependencies: tempDevDeps };
+};
+
+export { findNearestPackageJson, getPackage, returnShouldInstall };

--- a/sites/docs/src/hooks.client.ts
+++ b/sites/docs/src/hooks.client.ts
@@ -1,6 +1,0 @@
-import { dev } from '$app/environment';
-import { inject } from '@vercel/analytics';
-import { injectSpeedInsights } from '@vercel/speed-insights/sveltekit';
-
-injectSpeedInsights();
-inject({ mode: dev ? 'development' : 'production' });


### PR DESCRIPTION
Fixes #171 

Previously we just installed all dependencies no matter what if the user said yes. Now we are only ever going to install what we need based on what's currently in the `package.json`.