### PR TITLE
fix: General fixes

### DIFF
--- a/.changeset/eighty-numbers-stare.md
+++ b/.changeset/eighty-numbers-stare.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Fix a few things with logging

--- a/.changeset/good-socks-return.md
+++ b/.changeset/good-socks-return.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Show `<category>/<block>` when asking if users would like to overwrite a block.

--- a/.changeset/quiet-cherries-decide.md
+++ b/.changeset/quiet-cherries-decide.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Ensure `vitest` is only included as a devDependency if the block includes tests.

--- a/.changeset/twelve-garlics-peel.md
+++ b/.changeset/twelve-garlics-peel.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Use `<category>/<name>` as the key when resolving blocks to improve consistency.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,10 +6,7 @@
 		"type": "git",
 		"url": "git+https://github.com/ieedan/jsrepo"
 	},
-	"keywords": [
-		"repo",
-		"cli"
-	],
+	"keywords": ["repo", "cli"],
 	"author": "Aidan Bleser",
 	"license": "MIT",
 	"bugs": {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -292,6 +292,7 @@ const _add = async (blockNames: string[], options: Options) => {
 
 	for (const { block } of installingBlocks) {
 		const fullSpecifier = `${block.sourceRepo.url}/${block.category}/${block.name}`;
+		const shortSpecifier = `${block.category}/${block.name}`;
 		const watermark = getWatermark(context.package.version, block.sourceRepo.url);
 
 		const providerInfo = block.sourceRepo;
@@ -306,7 +307,7 @@ const _add = async (blockNames: string[], options: Options) => {
 
 		if (blockExists && !options.yes) {
 			const result = await confirm({
-				message: `${color.bold(block.name)} already exists in your project would you like to overwrite it?`,
+				message: `${color.cyan(shortSpecifier)} already exists in your project would you like to overwrite it?`,
 				initialValue: false,
 			});
 
@@ -334,16 +335,12 @@ const _add = async (blockNames: string[], options: Options) => {
 						verbose,
 					});
 
-					verbose(`Came back with response content for ${color.cyan(filePath)}`);
-
 					if (content.isErr()) {
 						loading.stop(color.red(`Error fetching ${color.bold(filePath)}`));
 						program.error(
 							color.red(`There was an error trying to get ${fullSpecifier}`)
 						);
 					}
-
-					verbose(`Came back with success response content for ${color.cyan(filePath)}`);
 
 					return content.unwrap();
 				};
@@ -364,13 +361,11 @@ const _add = async (blockNames: string[], options: Options) => {
 
 					const content = await getSourceFile(sourcePath);
 
-					verbose(`Setting up pathFolder for ${destPath}`);
-
 					const pathFolder = destPath.slice(0, destPath.length - sourceFile.length);
 
 					verbose(`Creating directory ${color.bold(pathFolder)}`);
 
-					fs.mkdirSync(destPath.slice(0, destPath.length - sourceFile.length), {
+					fs.mkdirSync(pathFolder, {
 						recursive: true,
 					});
 
@@ -408,14 +403,14 @@ const _add = async (blockNames: string[], options: Options) => {
 					fs.writeFileSync(file.destPath, content);
 				}
 
-				if (config.includeTests) {
+				if (config.includeTests && block.tests) {
 					verbose('Trying to include tests');
 
 					const { devDependencies } = JSON.parse(
 						fs.readFileSync(path.join(options.cwd, 'package.json')).toString()
 					);
 
-					if (devDependencies.vitest === undefined) {
+					if (devDependencies === undefined || devDependencies.vitest === undefined) {
 						devDeps.add('vitest');
 					}
 				}

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -323,14 +323,14 @@ const _update = async (blockNames: string[], options: Options) => {
 			}
 		}
 
-		if (config.includeTests) {
+		if (config.includeTests && block.tests) {
 			verbose('Trying to include tests');
 
 			const { devDependencies } = JSON.parse(
 				fs.readFileSync(path.join(options.cwd, 'package.json')).toString()
 			);
 
-			if (devDependencies.vitest === undefined) {
+			if (devDependencies === undefined || devDependencies.vitest === undefined) {
 				devDeps.add('vitest');
 			}
 		}

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -65,9 +65,9 @@ const resolveTree = async (
 			return Err(`Invalid block! ${color.bold(blockSpecifier)} does not exist!`);
 		}
 
-		const fullSpecifier = `${block.sourceRepo.name}/${block.sourceRepo.owner}/${block.sourceRepo.repoName}/${block.category}/${block.name}`;
+		const specifier = `${block.category}/${block.name}`;
 
-		blocks.set(fullSpecifier, { name: fullSpecifier, subDependency: false, block });
+		blocks.set(specifier, { name: block.name, subDependency: false, block });
 
 		if (block.localDependencies && block.localDependencies.length > 0) {
 			const subDeps = await resolveTree(

--- a/packages/cli/src/utils/git-providers.ts
+++ b/packages/cli/src/utils/git-providers.ts
@@ -122,17 +122,10 @@ const github: Provider = {
 			verbose?.(`Got a response from ${url} ${response.status} ${response.statusText}`);
 
 			if (!response.ok) {
-				verbose?.('response not ok');
 				return rawErrorMessage(info, resourcePath, github.defaultBranch());
 			}
 
-			verbose?.('Waiting for response.text()');
-
-			const text = await response.text();
-
-			verbose?.('response.text() done.');
-
-			return Ok(text);
+			return Ok(await response.text());
 		} catch (err) {
 			verbose?.(`erroring in response ${err} `);
 


### PR DESCRIPTION
- Only install vitest when blocks actually have tests
- Use `<category>/<name>` in resolveTree as the key
- Use `<category>/<name>` when asking if you'd like to overwrite the blocks