### PR TITLE
feat: Autodetect default branches for git providers

### DIFF
--- a/.changeset/real-crabs-rush.md
+++ b/.changeset/real-crabs-rush.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Auto detect default branch on **GitLab** and **BitBucket**.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"schema.json",
-		"dist"
-	],
+	"files": ["schema.json", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/utils/git-providers.ts
+++ b/packages/cli/src/utils/git-providers.ts
@@ -283,6 +283,32 @@ const gitlab: Provider = {
 			} else {
 				ref = rest[2];
 			}
+		} else {
+			try {
+				const token = persisted.get().get(`${gitlab.name()}-token`);
+
+				const headers = new Headers();
+
+				if (token !== undefined) {
+					headers.append('Authorization', `Bearer ${token}`);
+				}
+
+				const response = await fetch(
+					`https://gitlab.com/api/v4/projects/${encodeURIComponent(`${owner}/${repoName}`)}`,
+					{
+						headers,
+					}
+				);
+
+				if (response.ok) {
+					const data = await response.json();
+
+					// @ts-ignore yes but we know
+					ref = data.default_branch;
+				}
+			} catch {
+				// well find out it isn't correct later with a better error
+			}
 		}
 
 		return {

--- a/packages/cli/src/utils/git-providers.ts
+++ b/packages/cli/src/utils/git-providers.ts
@@ -372,6 +372,32 @@ const bitbucket: Provider = {
 
 		if (rest[0] === 'src') {
 			ref = rest[1];
+		} else {
+			try {
+				const token = persisted.get().get(`${bitbucket.name()}-token`);
+
+				const headers = new Headers();
+
+				if (token !== undefined) {
+					headers.append('Authorization', `Bearer ${token}`);
+				}
+
+				const response = await fetch(
+					`https://api.bitbucket.org/2.0/repositories/${owner}/${repoName}`,
+					{
+						headers,
+					}
+				);
+
+				if (response.ok) {
+					const data = await response.json();
+
+					// @ts-ignore yes but we know
+					ref = data.mainbranch.name;
+				}
+			} catch {
+				// well find out it isn't correct later with a better error
+			}
 		}
 
 		return {

--- a/sites/docs/src/routes/docs/git-providers/bitbucket/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/bitbucket/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { DocHeader, Jsrepo, Link, SubHeading, Code, Blockquote } from '$lib/components/site/docs';
+	import { DocHeader, Jsrepo, Link, SubHeading, Code } from '$lib/components/site/docs';
 	import CodeSpan from '$lib/components/site/docs/code-span.svelte';
 	import { Snippet } from '$lib/components/ui/snippet';
 
@@ -8,9 +8,6 @@
 
 <DocHeader title="BitBucket" description="How to use BitBucket as your jsrepo registry." />
 <SubHeading>Branches and Tags</SubHeading>
-<Blockquote variant="primary">
-	<Jsrepo /> will automatically detect the default branch for you.
-</Blockquote>
 <p>
 	<Jsrepo /> supports <Link target="_blank" href="https://bitbucket.org">BitBucket</Link> so that you
 	can just paste a link to the repo homepage and it will be handled correctly.

--- a/sites/docs/src/routes/docs/git-providers/bitbucket/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/bitbucket/+page.svelte
@@ -9,7 +9,7 @@
 <DocHeader title="BitBucket" description="How to use BitBucket as your jsrepo registry." />
 <SubHeading>Branches and Tags</SubHeading>
 <Blockquote variant="primary">
-	The default branch is <CodeSpan>master</CodeSpan>.
+	<Jsrepo /> will automatically detect the default branch for you.
 </Blockquote>
 <p>
 	<Jsrepo /> supports <Link target="_blank" href="https://bitbucket.org">BitBucket</Link> so that you
@@ -19,7 +19,7 @@
 <Code
 	showLines={false}
 	lang="bash"
-	code={`https://bitbucket.org/ieedan/std # master shorthand
+	code={`https://bitbucket.org/ieedan/std # default branch shorthand
 https://bitbucket.org/ieedan/std/src/v1.5.0 # tag reference
 https://bitbucket.org/ieedan/std/src/next # branch reference
 `}

--- a/sites/docs/src/routes/docs/git-providers/github/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/github/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { DocHeader, Jsrepo, Link, Blockquote, SubHeading, Code } from '$lib/components/site/docs';
+	import { DocHeader, Jsrepo, Link, SubHeading, Code } from '$lib/components/site/docs';
 	import CodeSpan from '$lib/components/site/docs/code-span.svelte';
 	import { Snippet } from '$lib/components/ui/snippet';
 
@@ -8,9 +8,6 @@
 
 <DocHeader title="GitHub" description="How to use GitHub as your jsrepo registry." />
 <SubHeading>Branches and Tags</SubHeading>
-<Blockquote variant="primary">
-	<Jsrepo /> will automatically detect the default branch for you.
-</Blockquote>
 <p>
 	<Jsrepo /> supports <Link target="_blank" href="https://github.com">GitHub</Link> so that you can just
 	paste a link to the repo homepage and it will be handled correctly.

--- a/sites/docs/src/routes/docs/git-providers/github/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/github/+page.svelte
@@ -9,8 +9,7 @@
 <DocHeader title="GitHub" description="How to use GitHub as your jsrepo registry." />
 <SubHeading>Branches and Tags</SubHeading>
 <Blockquote variant="primary">
-	<Jsrepo /> uses <CodeSpan>octokit</CodeSpan> to detect the default branch if a branch or tag is not
-	supplied.
+	<Jsrepo /> will automatically detect the default branch for you.
 </Blockquote>
 <p>
 	<Jsrepo /> supports <Link target="_blank" href="https://github.com">GitHub</Link> so that you can just
@@ -20,15 +19,11 @@
 <Code
 	showLines={false}
 	lang="bash"
-	code={`https://github.com/ieedan/std # main shorthand
+	code={`https://github.com/ieedan/std # default branch shorthand
 https://github.com/ieedan/std/tree/v1.5.0 # tag reference
 https://github.com/ieedan/std/tree/next # branch reference
 `}
 />
-<Blockquote variant="primary">
-	To check if a ref is a tag or a branch the CLI calls
-	<CodeSpan>octokit</CodeSpan> to check the tags.
-</Blockquote>
 <SubHeading>Using Tags for Versioning</SubHeading>
 <p>
 	Tags can be a great solution to ensuring remote tests and blocks stay on a consistent version.

--- a/sites/docs/src/routes/docs/git-providers/gitlab/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/gitlab/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { DocHeader, Jsrepo, Link, SubHeading, Code, Blockquote } from '$lib/components/site/docs';
+	import { DocHeader, Jsrepo, Link, SubHeading, Code } from '$lib/components/site/docs';
 	import CodeSpan from '$lib/components/site/docs/code-span.svelte';
 	import { Snippet } from '$lib/components/ui/snippet';
 
@@ -8,9 +8,6 @@
 
 <DocHeader title="GitLab" description="How to use GitLab as your jsrepo registry." />
 <SubHeading>Branches and Tags</SubHeading>
-<Blockquote variant="primary">
-	<Jsrepo /> will automatically detect the default branch for you.
-</Blockquote>
 <p>
 	<Jsrepo /> supports <Link target="_blank" href="https://gitlab.com">GitLab</Link> so that you can just
 	paste a link to the repo homepage and it will be handled correctly.

--- a/sites/docs/src/routes/docs/git-providers/gitlab/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/gitlab/+page.svelte
@@ -9,7 +9,7 @@
 <DocHeader title="GitLab" description="How to use GitLab as your jsrepo registry." />
 <SubHeading>Branches and Tags</SubHeading>
 <Blockquote variant="primary">
-	The default branch is <CodeSpan>main</CodeSpan>.
+	<Jsrepo /> will automatically detect the default branch for you.
 </Blockquote>
 <p>
 	<Jsrepo /> supports <Link target="_blank" href="https://gitlab.com">GitLab</Link> so that you can just
@@ -19,9 +19,9 @@
 <Code
 	showLines={false}
 	lang="bash"
-	code={`https://gitlab.com/ieedan/std # main shorthand
-https://gitlab.com/ieedan/std/tree/v1.5.0 # tag reference
-https://gitlab.com/ieedan/std/tree/next # branch reference
+	code={`https://gitlab.com/ieedan/std # default branch shorthand
+https://gitlab.com/ieedan/std/-/tree/v1.5.0 # tag reference
+https://gitlab.com/ieedan/std/-/tree/next # branch reference
 `}
 />
 <SubHeading>Using Tags for Versioning</SubHeading>


### PR DESCRIPTION
GitHub already does this I just hadn't added it to the other GitLab and BitBucket yet. 

So now when using `gitlab/ieedan/std` or `bitbucket/ieedan/std` it won't just point to a hard coded default branch `main` and `master` but will instead lookup the default branch and point to that.