### PR TITLE
feat: When adding a new repo with `init` preconfigured paths should default to their configured value

### DIFF
--- a/.changeset/eight-news-beg.md
+++ b/.changeset/eight-news-beg.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+When adding a new repo with `init` and configuring paths, paths that already had a value will default to that value.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -236,12 +236,16 @@ const _initProject = async (options: Options) => {
 
 			if (configurePaths.length > 0) {
 				for (const category of configurePaths) {
+					const configuredValue = paths[category];
+
 					const categoryPath = await text({
 						message: `Where should ${category} be added in your project?`,
 						validate(value) {
 							if (value.trim() === '') return 'Please provide a value';
 						},
-						placeholder: `./src/${category}`,
+						placeholder: configuredValue ? configuredValue : `./src/${category}`,
+						defaultValue: configuredValue,
+						initialValue: configuredValue,
 					});
 
 					if (isCancel(categoryPath)) {


### PR DESCRIPTION
Fixes #234 