### PR TITLE
fix: Resolve paths to category root to an `index` block 

### DIFF
--- a/.changeset/dull-spies-wink.md
+++ b/.changeset/dull-spies-wink.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Imports like `$lib/assets/icons` that end up resolving to the category root will not resolve to `$lib/assets/icons/index` as is the expected behavior with JS.

--- a/.changeset/sixty-bears-serve.md
+++ b/.changeset/sixty-bears-serve.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+`*.svg` support.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/utils/language-support.ts
+++ b/packages/cli/src/utils/language-support.ts
@@ -239,6 +239,14 @@ const yaml: Lang = {
 	},
 };
 
+const svg: Lang = {
+	matches: (fileName) => fileName.endsWith('.svg'),
+	resolveDependencies: () =>
+		Ok({ dependencies: [], local: [], devDependencies: [], imports: {} }),
+	comment: (content) => `<!--\n${lines.join(lines.get(content), { prefix: () => '\t' })}\n-->`,
+	format: async (code) => code,
+};
+
 const json: Lang = {
 	matches: (fileName) => fileName.endsWith('.json'),
 	resolveDependencies: () =>
@@ -410,7 +418,12 @@ const resolveLocalImport = (
 };
 
 const parsePath = (localPath: string): ResolveLocalImportResult => {
-	const [category, block, ...rest] = localPath.split('/');
+	let [category, block, ...rest] = localPath.split('/');
+
+	// if undefined we assume we are pointing to the index file
+	if (block === undefined) {
+		block = 'index';
+	}
 
 	let trimmedBlock = block;
 
@@ -621,6 +634,6 @@ const resolveRemoteDeps = (
 	};
 };
 
-const languages: Lang[] = [typescript, svelte, vue, yaml, json];
+const languages: Lang[] = [typescript, svelte, vue, yaml, json, svg];
 
-export { typescript, svelte, vue, yaml, json, languages };
+export { typescript, svelte, vue, yaml, json, svg, languages };

--- a/sites/docs/src/lib/components/icons/index.ts
+++ b/sites/docs/src/lib/components/icons/index.ts
@@ -9,6 +9,7 @@ import Jsrepo from './jsrepo.svelte';
 import GitLab from './gitlab.svelte';
 import BitBucket from './bitbucket.svelte';
 import Yaml from './yaml.svelte';
+import Svg from './svg.svelte';
 
 export interface Props extends HTMLAttributes<SVGElement> {
 	class?: string;
@@ -16,4 +17,4 @@ export interface Props extends HTMLAttributes<SVGElement> {
 	height?: number;
 }
 
-export { GitHub, TypeScript, Svelte, React, JavaScript, Vue, Jsrepo, GitLab, BitBucket, Yaml };
+export { GitHub, TypeScript, Svelte, React, JavaScript, Vue, Jsrepo, GitLab, BitBucket, Yaml, Svg };

--- a/sites/docs/src/lib/components/icons/svg.svelte
+++ b/sites/docs/src/lib/components/icons/svg.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import type { Props } from '.';
+	import { cn } from '$lib/utils';
+
+	let { class: className, ...rest }: Props = $props();
+</script>
+
+<svg
+	class={cn('size-4', className)}
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	viewBox="0 0 300 300"
+	{...rest}
+	><g stroke="#000" stroke-width="38.009"
+		><g id="svgstar" transform="translate(150 150)"
+			><path
+				id="svgbar"
+				fill="#ffb13b"
+				d="M-84.149-15.851a22.417 22.417 0 1 0 0 31.702H84.15a22.417 22.417 0 1 0 0-31.702Z"
+			/><use xlink:href="#svgbar" transform="rotate(45)" /><use
+				xlink:href="#svgbar"
+				transform="rotate(90)"
+			/><use xlink:href="#svgbar" transform="rotate(135)" /></g
+		></g
+	><use xlink:href="#svgstar" /></svg
+>

--- a/sites/docs/src/routes/docs/language-support/+page.svelte
+++ b/sites/docs/src/routes/docs/language-support/+page.svelte
@@ -51,6 +51,11 @@
 			logo: json,
 			name: '*.json',
 			status: '⚠️'
+		},
+		{
+			logo: svg,
+			name: '*.svg',
+			status: '⚠️'
 		}
 	];
 </script>
@@ -87,6 +92,10 @@
 
 {#snippet json({ size }: { size: number })}
 	<Braces height={size} class="size-[18px] text-[#f7df1e]" />
+{/snippet}
+
+{#snippet svg({ size }: { size: number })}
+	<Icons.Svg height={size} class="size-auto" />
 {/snippet}
 
 <DocHeader


### PR DESCRIPTION
Previously if you had an import to the category root like `$lib/assets/icons` jsrepo would just crash because there would be no block specifier. Now it resolves that path to `$lib/assets/icons/index` as is consistent with JS expected behavior.

- Add `*.svg` support