### PR TITLE
perf: Improve performance when resolving blocks

### DIFF
--- a/.changeset/eighty-cooks-sin.md
+++ b/.changeset/eighty-cooks-sin.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Fixes issue where configuring paths was required when adding a repo on `init`.

--- a/.changeset/young-experts-clean.md
+++ b/.changeset/young-experts-clean.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Improve performance when resolving an excessive amount of blocks at once.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -75,10 +75,20 @@ const _diff = async (options: Options) => {
 		}
 	}
 
+	const resolvedRepos: gitProviders.ResolvedRepo[] = (
+		await gitProviders.resolvePaths(...repoPaths)
+	).match(
+		(val) => val,
+		({ repo, message }) => {
+			loading.stop(`Failed to get info for ${color.cyan(repo)}`);
+			program.error(color.red(message));
+		}
+	);
+
 	loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
 
 	const blocksMap: Map<string, RemoteBlock> = (
-		await gitProviders.fetchBlocks(...repoPaths)
+		await gitProviders.fetchBlocks(...resolvedRepos)
 	).match(
 		(val) => val,
 		({ repo, message }) => {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -227,6 +227,7 @@ const _initProject = async (options: Options) => {
 			const configurePaths = await multiselect({
 				message: 'Which category paths would you like to configure?',
 				options: categories.map((cat) => ({ label: cat.name, value: cat.name })),
+				required: false,
 			});
 
 			if (isCancel(configurePaths)) {

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -19,7 +19,7 @@ export type InstallingBlock = {
 const resolveTree = async (
 	blockSpecifiers: string[],
 	blocksMap: Map<string, RemoteBlock>,
-	repoPaths: string[]
+	repoPaths: gitProviders.ResolvedRepo[]
 ): Promise<Result<InstallingBlock[], string>> => {
 	const blocks = new Map<string, InstallingBlock>();
 
@@ -39,10 +39,7 @@ const resolveTree = async (
 			}
 
 			// check every repo for the block and return the first block found
-			for (const repo of repoPaths) {
-				// we unwrap because we already checked this
-				const providerInfo = (await gitProviders.getProviderInfo(repo)).unwrap();
-
+			for (const { info: providerInfo } of repoPaths) {
 				const tempBlock = blocksMap.get(
 					`${providerInfo.name}/${providerInfo.owner}/${providerInfo.repoName}/${blockSpecifier}`
 				);


### PR DESCRIPTION
For some reason we would re-fetch info about each repo for every block. This never should have been the case. This fixes it so that we get the info once at the beginning and then never again.