### PR TITLE
feat: Improve post build manifest validation

### DIFF
--- a/.changeset/healthy-balloons-perform.md
+++ b/.changeset/healthy-balloons-perform.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Remove `output` and `errorOnWarn` keys from `jsrepo-build-config.json` as they are both useless now.

--- a/.changeset/hungry-cups-beg.md
+++ b/.changeset/hungry-cups-beg.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Add `rules` key to `jsrepo-build-config.json` to allow you to configure rules when checking the manifest after build.

--- a/examples/registry/jsrepo-build-config.json
+++ b/examples/registry/jsrepo-build-config.json
@@ -1,11 +1,9 @@
 {
-	"$schema": "https://unpkg.com/jsrepo@1.16.0/schemas/project-config.json",
+	"$schema": "https://unpkg.com/jsrepo@1.17.0/schemas/project-config.json",
 	"dirs": ["./src", "./blocks"],
 	"doNotListBlocks": [],
 	"doNotListCategories": ["utils"],
-	"errorOnWarn": false,
 	"excludeDeps": [],
 	"includeBlocks": [],
-	"includeCategories": [],
-	"output": true
+	"includeCategories": []
 }

--- a/examples/registry/src/types/index.ts
+++ b/examples/registry/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './point'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -60,7 +60,7 @@
 					"enum": ["error", "warn", "off"],
 					"default": "warn"
 				},
-				"require-dependency-exists": {
+				"require-local-dependency-exists": {
 					"description": "Require all local dependencies to exist.",
 					"type": "string",
 					"enum": ["error", "warn", "off"],
@@ -87,7 +87,7 @@
 			"default": {
 				"no-category-index-file-dependency": "warn",
 				"no-unpinned-dependency": "warn",
-				"require-dependency-exists": "error",
+				"require-local-dependency-exists": "error",
 				"max-local-dependencies": ["warn", 10]
 			}
 		}

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -44,16 +44,53 @@
 				"type": "string"
 			}
 		},
-		"output": {
-			"description": "Should the build output a manifest file.",
-			"type": "boolean",
-			"default": true
-		},
-		"errorOnWarn": {
-			"description": "Should the CLI error on warnings.",
-			"type": "boolean",
-			"default": false
+		"rules": {
+			"description": "Configure rules when checking manifest after build.",
+			"type": "object",
+			"properties": {
+				"no-category-index-file-dependency": {
+					"description": "Disallow depending on the index file of a category.",
+					"type": "string",
+					"enum": ["error", "warn", "off"],
+					"default": "warn"
+				},
+				"no-unpinned-dependency": {
+					"description": "Require all dependencies to have a pinned version.",
+					"type": "string",
+					"enum": ["error", "warn", "off"],
+					"default": "warn"
+				},
+				"require-dependency-exists": {
+					"description": "Require all local dependencies to exist.",
+					"type": "string",
+					"enum": ["error", "warn", "off"],
+					"default": "error"
+				},
+				"max-local-dependencies": {
+					"description": "Enforces a limit on the amount of local dependencies a block can have.",
+					"type": "array",
+					"items": [
+						{
+							"type": "string",
+							"enum": ["error", "warn", "off"],
+							"default": "warn"
+						},
+						{
+							"description": "Max local dependencies",
+							"type": "number",
+							"default": 10
+						}
+					],
+					"default": ["warn", 10]
+				}
+			},
+			"default": {
+				"no-category-index-file-dependency": "warn",
+				"no-unpinned-dependency": "warn",
+				"require-dependency-exists": "error",
+				"max-local-dependencies": ["warn", 10]
+			}
 		}
 	},
-	"required": ["dirs", "output", "errorOnWarn"]
+	"required": ["dirs"]
 }

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -10,6 +10,7 @@ import { type Category, buildBlocksDirectory } from '../utils/build';
 import { type RegistryConfig, getRegistryConfig } from '../utils/config';
 import { OUTPUT_FILE } from '../utils/context';
 import { intro } from '../utils/prompts';
+import { rules, runRules } from '../utils/build/check';
 
 const schema = v.object({
 	dirs: v.optional(v.array(v.string())),
@@ -139,66 +140,29 @@ const _build = async (options: Options) => {
 
 	loading.start('Checking manifest');
 
-	const warnings: string[] = [];
-
-	for (const category of categories) {
-		for (const block of category.blocks) {
-			// lookup local deps
-			for (const dep of block.localDependencies) {
-				const [depCategoryName, depBlockName] = dep.split('/');
-
-				const depCategory = categories.find(
-					(cat) => cat.name.trim() === depCategoryName.trim()
-				);
-
-				const invalidDependencyError = () => {
-					const error = `depends on ${color.bold(dep)} which doesn't exist!`;
-
-					if (config.errorOnWarn) {
-						warnings.push(
-							color.red(`${color.bold(`${category.name}/${block.name}`)} ${error}`)
-						);
-					} else {
-						warnings.push(
-							`${ascii.VERTICAL_LINE}  ${ascii.WARN} ${color.bold(`${category.name}/${block.name}`)} ${error}`
-						);
-					}
-				};
-
-				if (!depCategory) {
-					invalidDependencyError();
-					continue;
-				}
-
-				if (depCategory.blocks.find((b) => b.name === depBlockName) === undefined) {
-					invalidDependencyError();
-				}
-			}
-
-			for (const dep of [...block.dependencies, ...block.devDependencies]) {
-				if (!dep.includes('@')) {
-					const error = `You haven't installed ${color.bold(dep)} as a dependency so your users could get any version of it when they install your block!`;
-
-					if (config.errorOnWarn) {
-						warnings.push(color.red(error));
-					} else {
-						warnings.push(`${ascii.VERTICAL_LINE}  ${ascii.WARN} ${error}`);
-					}
-				}
-			}
-		}
-	}
+	const { warnings, errors } = runRules(categories);
 
 	loading.stop('Completed checking manifest.');
 
-	if (warnings.length > 0) {
-		for (const warning of warnings) {
-			console.log(warning);
+	// add gap for errors
+	if (warnings.length > 0 || errors.length > 0) {
+		console.log(ascii.VERTICAL_LINE);
+	}
+
+	for (const warning of warnings) {
+		console.log(warning);
+	}
+
+	if (errors.length > 0) {
+		for (const error of errors) {
+			console.log(error);
 		}
 
-		if (config.errorOnWarn) {
-			program.error('Had warnings while checking manifest.');
-		}
+		program.error(
+			color.red(
+				`Completed checking manifest with ${color.bold(`${errors.length} error(s)`)} and ${color.bold(`${warnings.length} warning(s)`)}`
+			)
+		);
 	}
 
 	if (config.output) {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -7,7 +7,7 @@ import * as v from 'valibot';
 import { context } from '..';
 import * as ascii from '../utils/ascii';
 import { type Category, buildBlocksDirectory } from '../utils/build';
-import { runRules } from '../utils/build/check';
+import { DEFAULT_CONFIG, runRules } from '../utils/build/check';
 import { type RegistryConfig, getRegistryConfig } from '../utils/config';
 import { OUTPUT_FILE } from '../utils/context';
 import { intro } from '../utils/prompts';
@@ -86,6 +86,8 @@ const _build = async (options: Options) => {
 			if (options.includeBlocks) mergedVal.includeBlocks = options.includeBlocks;
 			if (options.includeCategories) mergedVal.includeCategories = options.includeCategories;
 			if (options.excludeDeps) mergedVal.excludeDeps = options.excludeDeps;
+
+			mergedVal.rules = { ...DEFAULT_CONFIG, ...mergedVal.rules };
 
 			return mergedVal;
 		},

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -352,8 +352,6 @@ const _initRegistry = async (options: Options) => {
 			excludeDeps: [],
 			includeBlocks: [],
 			includeCategories: [],
-			errorOnWarn: false,
-			output: true,
 		};
 	}
 

--- a/packages/cli/src/utils/ascii.ts
+++ b/packages/cli/src/utils/ascii.ts
@@ -8,8 +8,8 @@ export const JUNCTION_RIGHT = color.gray('├');
 export const TOP_LEFT_CORNER = color.gray('┌');
 export const BOTTOM_LEFT_CORNER = color.gray('└');
 
-export const WARN = color.bgRgb(245, 149, 66).white('WARN');
-export const INFO = color.bgBlueBright.white('INFO');
-export const ERROR = color.bgRedBright.white('ERROR');
+export const WARN = color.bgRgb(245, 149, 66).black(' WARN ');
+export const INFO = color.bgBlueBright.white(' INFO ');
+export const ERROR = color.bgRedBright.white(' ERROR ');
 
 export const JSREPO = color.hex('#f7df1e')('jsrepo');

--- a/packages/cli/src/utils/build/check.ts
+++ b/packages/cli/src/utils/build/check.ts
@@ -1,0 +1,173 @@
+import type { Block, Category } from '.';
+import color from 'chalk';
+import * as ascii from '../ascii';
+import { program } from 'commander';
+
+export type RuleLevel = 'off' | 'warn' | 'error';
+
+export type CheckOptions = {
+	categories: Category[];
+	options: (string | number)[];
+};
+
+export type Rule = {
+	description: string;
+	check: (block: Block, { categories }: CheckOptions) => string[] | undefined;
+};
+
+const rules = {
+	'no-unpinned-dependency': {
+		description: 'Require all dependencies to have a pinned version.',
+		check: (block) => {
+			const errors: string[] = [];
+
+			for (const dep of [...block.dependencies, ...block.devDependencies]) {
+				if (!dep.includes('@')) {
+					errors.push(`Couldn't find a version to use for ${color.bold(dep)}`);
+				}
+			}
+
+			return errors.length > 0 ? errors : undefined;
+		},
+	} satisfies Rule,
+	'require-dependency-exists': {
+		description: 'Require all local dependencies to exist.',
+		check: (block, { categories }) => {
+			const errors: string[] = [];
+
+			for (const dep of block.localDependencies) {
+				const [depCategoryName, depBlockName] = dep.split('/');
+
+				const depCategory = categories.find(
+					(cat) => cat.name.trim() === depCategoryName.trim()
+				);
+
+				const error = `${color.bold(`${block.category}/${block.name}`)} depends on local dependency ${color.bold(dep)} which doesn't exist`;
+
+				if (!depCategory) {
+					errors.push(error);
+					continue;
+				}
+
+				if (depCategory.blocks.find((b) => b.name === depBlockName) === undefined) {
+					errors.push(error);
+				}
+			}
+
+			return errors.length > 0 ? errors : undefined;
+		},
+	} satisfies Rule,
+	'no-category-index-file-dependency': {
+		description: 'Disallow depending on the index file of a category.',
+		check: (block, { categories }) => {
+			const errors: string[] = [];
+
+			for (const dep of block.localDependencies) {
+				const [categoryName, name] = dep.split('/');
+
+				if (name !== 'index') continue;
+
+				const category = categories.find((cat) => cat.name === categoryName);
+
+				if (!category) continue;
+
+				const depBlock = category.blocks.find((b) => b.name === name);
+
+				if (!depBlock) continue;
+
+				errors.push(
+					`${color.bold(`${block.category}/${block.name}`)} depends on ${color.bold(`${categoryName}/${name}`)}`
+				);
+			}
+
+			return errors.length > 0 ? errors : undefined;
+		},
+	} satisfies Rule,
+	'max-local-dependencies': {
+		description: 'Enforces a limit on the amount of local dependencies a block can have.',
+		check: (block, { options }) => {
+			const errors: string[] = [];
+
+			let limit: number;
+
+			if (typeof options[0] !== 'number') {
+				limit = 5;
+			} else {
+				limit = options[0];
+			}
+
+			if (block.localDependencies.length > limit) {
+				errors.push(
+					`${color.bold(`${block.category}/${block.name}`)} has too many local dependencies (${color.bold(block.localDependencies.length)}) limit (${color.bold(limit)})`
+				);
+			}
+
+			return errors.length > 0 ? errors : undefined;
+		},
+	} satisfies Rule,
+} as const;
+
+export type RuleKey = keyof typeof rules;
+
+export type RuleConfig = Record<
+	keyof typeof rules,
+	RuleLevel | [RuleLevel, ...(number | string)[]]
+>;
+
+const DEFAULT_CONFIG: RuleConfig = {
+	'no-category-index-file-dependency': 'warn',
+	'no-unpinned-dependency': 'warn',
+	'require-dependency-exists': 'error',
+	'max-local-dependencies': ['warn', 10],
+} as const;
+
+const runRules = (
+	categories: Category[],
+	config: RuleConfig = DEFAULT_CONFIG
+): { warnings: string[]; errors: string[] } => {
+	const warnings: string[] = [];
+	const errors: string[] = [];
+
+	for (const category of categories) {
+		for (const block of category.blocks) {
+			for (const [name, rule] of Object.entries(rules)) {
+				const conf = config[name as RuleKey];
+
+				let level: RuleLevel;
+				const options: (string | number)[] = [];
+				if (Array.isArray(conf)) {
+					level = conf[0];
+					options.push(...conf.slice(1));
+				} else {
+					level = conf;
+				}
+
+				if (level === 'off') continue;
+
+				const ruleErrors = rule.check(block, { categories, options });
+
+				if (!ruleErrors) continue;
+
+				if (level === 'error') {
+					errors.push(
+						...ruleErrors.map(
+							(err) =>
+								`${ascii.VERTICAL_LINE}  ${ascii.ERROR} ${color.red(err)} ${color.gray(name)}`
+						)
+					);
+					continue;
+				}
+
+				warnings.push(
+					...ruleErrors.map(
+						(err) => `${ascii.VERTICAL_LINE}  ${ascii.WARN} ${err} ${color.gray(name)}`
+					)
+				);
+			}
+		}
+	}
+
+	return { warnings, errors };
+};
+
+export { rules, runRules, DEFAULT_CONFIG };

--- a/packages/cli/src/utils/build/check.ts
+++ b/packages/cli/src/utils/build/check.ts
@@ -32,7 +32,7 @@ const rules = {
 			return errors.length > 0 ? errors : undefined;
 		},
 	} satisfies Rule,
-	'require-dependency-exists': {
+	'require-local-dependency-exists': {
 		description: 'Require all local dependencies to exist.',
 		check: (block, { categories }) => {
 			const errors: string[] = [];
@@ -112,7 +112,7 @@ const rules = {
 const ruleKeySchema = v.union([
 	v.literal('no-category-index-file-dependency'),
 	v.literal('no-unpinned-dependency'),
-	v.literal('require-dependency-exists'),
+	v.literal('require-local-dependency-exists'),
 	v.literal('max-local-dependencies'),
 ]);
 
@@ -134,7 +134,7 @@ export type RuleConfig = v.InferInput<typeof ruleConfigSchema>;
 const DEFAULT_CONFIG: RuleConfig = {
 	'no-category-index-file-dependency': 'warn',
 	'no-unpinned-dependency': 'warn',
-	'require-dependency-exists': 'error',
+	'require-local-dependency-exists': 'error',
 	'max-local-dependencies': ['warn', 10],
 } as const;
 

--- a/packages/cli/src/utils/build/index.ts
+++ b/packages/cli/src/utils/build/index.ts
@@ -3,9 +3,9 @@ import color from 'chalk';
 import { program } from 'commander';
 import path from 'pathe';
 import * as v from 'valibot';
-import * as ascii from './ascii';
-import type { RegistryConfig } from './config';
-import { languages } from './language-support';
+import * as ascii from '../ascii';
+import type { RegistryConfig } from '../config';
+import { languages } from '../language-support';
 
 export const blockSchema = v.object({
 	name: v.string(),

--- a/packages/cli/src/utils/build/index.ts
+++ b/packages/cli/src/utils/build/index.ts
@@ -54,7 +54,6 @@ const buildBlocksDirectory = (
 			excludeDeps,
 			includeBlocks,
 			includeCategories,
-			errorOnWarn,
 			dirs,
 			doNotListBlocks,
 			doNotListCategories,
@@ -116,21 +115,11 @@ const buildBlocksDirectory = (
 				if (!lang) {
 					const error = 'files are not currently supported!';
 
-					if (errorOnWarn) {
-						program.error(
-							color.red(
-								`Couldn't add \`${color.bold(blockDir)}\` \`*${color.bold(
-									path.parse(file).ext
-								)}\` ${error}`
-							)
-						);
-					} else {
-						console.warn(
-							`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(blockDir)}\` \`*${color.bold(
-								path.parse(file).ext
-							)}\` ${error}`
-						);
-					}
+					console.warn(
+						`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(blockDir)}\` \`*${color.bold(
+							path.parse(file).ext
+						)}\` ${error}`
+					);
 
 					continue;
 				}
@@ -202,17 +191,9 @@ const buildBlocksDirectory = (
 					if (fs.statSync(path.join(blockDir, f)).isDirectory()) {
 						const error = 'subdirectories are not currently supported!';
 
-						if (errorOnWarn) {
-							program.error(
-								color.red(
-									`Couldn't add \`${color.bold(path.join(blockDir, f))}\` ${error}`
-								)
-							);
-						} else {
-							console.warn(
-								`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(path.join(blockDir, f))}\` ${error}`
-							);
-						}
+						console.warn(
+							`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${color.bold(path.join(blockDir, f))}\` ${error}`
+						);
 						continue;
 					}
 
@@ -221,21 +202,11 @@ const buildBlocksDirectory = (
 					if (!lang) {
 						const error = 'files are not currently supported!';
 
-						if (errorOnWarn) {
-							program.error(
-								color.red(
-									`Couldn't add \`${color.bold(path.join(blockDir, f))}\` \`*${color.bold(
-										path.parse(f).ext
-									)}\` ${error}`
-								)
-							);
-						} else {
-							console.warn(
-								`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${path.join(blockDir, f)}\` \`*${color.bold(
-									path.parse(f).ext
-								)}\` ${error}`
-							);
-						}
+						console.warn(
+							`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped \`${path.join(blockDir, f)}\` \`*${color.bold(
+								path.parse(f).ext
+							)}\` ${error}`
+						);
 						continue;
 					}
 

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -3,6 +3,7 @@ import { createPathsMatcher, getTsconfig } from 'get-tsconfig';
 import path from 'pathe';
 import * as v from 'valibot';
 import { Err, Ok, type Result } from './blocks/types/result';
+import { ruleConfigSchema } from './build/check';
 
 const PROJECT_CONFIG_NAME = 'jsrepo.json';
 const REGISTRY_CONFIG_NAME = 'jsrepo-build-config.json';
@@ -56,8 +57,7 @@ const registryConfigSchema = v.object({
 	doNotListBlocks: v.optional(v.array(v.string()), []),
 	doNotListCategories: v.optional(v.array(v.string()), []),
 	excludeDeps: v.optional(v.array(v.string()), []),
-	output: v.boolean(),
-	errorOnWarn: v.boolean(),
+	rules: v.optional(ruleConfigSchema),
 });
 
 const getRegistryConfig = (cwd: string): Result<RegistryConfig | null, string> => {

--- a/packages/cli/src/utils/language-support.ts
+++ b/packages/cli/src/utils/language-support.ts
@@ -588,7 +588,7 @@ const resolveRemoteDeps = (
 
 			if (parsed.isErr()) {
 				console.warn(
-					`${ascii.WARN} Skipped adding import \`${color.cyan(dep)}\`. Reason: Couldn't parse package name`
+					`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped adding import \`${color.cyan(dep)}\`. Reason: Couldn't parse package name`
 				);
 				continue;
 			}
@@ -597,7 +597,7 @@ const resolveRemoteDeps = (
 
 			if (!validatePackageName(depInfo.name).validForNewPackages) {
 				console.warn(
-					`${ascii.WARN} Skipped adding import \`${color.cyan(dep)}\`. Reason: Not a valid package name`
+					`${ascii.VERTICAL_LINE}  ${ascii.WARN} Skipped adding import \`${color.cyan(dep)}\`. Reason: Not a valid package name`
 				);
 				continue;
 			}

--- a/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
+++ b/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
@@ -121,7 +121,7 @@
     "rules": {
 		"no-category-index-file-dependency": "warn",
 		"no-unpinned-dependency": "warn",
-		"require-dependency-exists": "error",
+		"require-local-dependency-exists": "error",
 		"max-local-dependencies": ["warn", 10]
 	}
 }`}
@@ -135,7 +135,7 @@
 	<p>Require all dependencies to have a pinned version.</p>
 </div>
 <div class="flex flex-col gap-2">
-	<CodeSpan class="w-fit">require-dependency-exists</CodeSpan>
+	<CodeSpan class="w-fit">require-local-dependency-exists</CodeSpan>
 	<p>Require all local dependencies to exist.</p>
 </div>
 <div class="flex flex-col gap-2">

--- a/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
+++ b/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
@@ -109,24 +109,36 @@
     ]
 }`}
 />
-<SubHeading>errorOnWarn</SubHeading>
+<SubHeading>rules</SubHeading>
 <p>
-	<CodeSpan>errorOnWarn</CodeSpan> will cause the build command to exit early and not create a manifest
-	file if a warning is detected.
+	<CodeSpan>rules</CodeSpan> allows you to configure the rules when checking the manifest file after
+	build.
 </p>
+<p>Below are the default settings for each rule.</p>
 <Code
 	lang="json"
 	code={`{
-    "errorOnWarn": false
+    "rules": {
+		"no-category-index-file-dependency": "warn",
+		"no-unpinned-dependency": "warn",
+		"require-dependency-exists": "error",
+		"max-local-dependencies": ["warn", 10]
+	}
 }`}
 />
-<SubHeading>output</SubHeading>
-<p>
-	<CodeSpan>output</CodeSpan> setting output to false will prevent an output file from being created.
-</p>
-<Code
-	lang="json"
-	code={`{
-    "output": true
-}`}
-/>
+<div class="flex flex-col gap-2">
+	<CodeSpan class="w-fit">no-category-index-file-dependency</CodeSpan>
+	<p>Disallow depending on the index file of a category.</p>
+</div>
+<div class="flex flex-col gap-2">
+	<CodeSpan class="w-fit">no-unpinned-dependency</CodeSpan>
+	<p>Require all dependencies to have a pinned version.</p>
+</div>
+<div class="flex flex-col gap-2">
+	<CodeSpan class="w-fit">require-dependency-exists</CodeSpan>
+	<p>Require all local dependencies to exist.</p>
+</div>
+<div class="flex flex-col gap-2">
+	<CodeSpan class="w-fit">max-local-dependencies</CodeSpan>
+	<p>Enforces a limit on the amount of local dependencies a block can have.</p>
+</div>


### PR DESCRIPTION
Fixes #248 

- Converts the current rules into eslint-style configurable rules.
- Adds a few helpful rules `max-local-dependencies` and `no-category-index-file-dependency` that should help warn of common pitfalls
- Removes `output` and `errorOnWarn` config options since they no longer do anything