### PR TITLE
feat: add `no-circular-dependency` rule

### DIFF
--- a/.changeset/spotty-elephants-occur.md
+++ b/.changeset/spotty-elephants-occur.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Add `no-circular-dependency` rule to catch circular dependencies early on.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -82,13 +82,20 @@
 						}
 					],
 					"default": ["warn", 10]
+				},
+				"no-circular-dependency": {
+					"description": "Disallow circular dependencies.",
+					"type": "string",
+					"enum": ["error", "warn", "off"],
+					"default": "error"
 				}
 			},
 			"default": {
 				"no-category-index-file-dependency": "warn",
 				"no-unpinned-dependency": "warn",
 				"require-local-dependency-exists": "error",
-				"max-local-dependencies": ["warn", 10]
+				"max-local-dependencies": ["warn", 10],
+				"no-circular-dependency": "error"
 			}
 		}
 	},

--- a/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
+++ b/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
@@ -122,7 +122,8 @@
 		"no-category-index-file-dependency": "warn",
 		"no-unpinned-dependency": "warn",
 		"require-local-dependency-exists": "error",
-		"max-local-dependencies": ["warn", 10]
+		"max-local-dependencies": ["warn", 10],
+		"no-circular-dependency": "error"
 	}
 }`}
 />
@@ -141,4 +142,8 @@
 <div class="flex flex-col gap-2">
 	<CodeSpan class="w-fit">max-local-dependencies</CodeSpan>
 	<p>Enforces a limit on the amount of local dependencies a block can have.</p>
+</div>
+<div class="flex flex-col gap-2">
+	<CodeSpan class="w-fit">no-circular-dependency</CodeSpan>
+	<p>Disallow circular dependencies.</p>
 </div>


### PR DESCRIPTION
Helps you identify and prevent circular dependencies during build.