### PR TITLE
fix: Fix an issue where a circular dependency in a registry would cause the CLI to crash

### DIFF
--- a/.changeset/violet-crabs-approve.md
+++ b/.changeset/violet-crabs-approve.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Prevent crashing because of a circular dependency.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -172,6 +172,8 @@ const _add = async (blockNames: string[], options: Options) => {
 
 	verbose(`Resolving ${color.cyan(repoPaths.join(', '))}`);
 
+	if (!options.verbose) loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
+
 	const resolvedRepos: gitProviders.ResolvedRepo[] = (
 		await gitProviders.resolvePaths(...repoPaths)
 	).match(
@@ -185,8 +187,6 @@ const _add = async (blockNames: string[], options: Options) => {
 	verbose(`Resolved ${color.cyan(repoPaths.join(', '))}`);
 
 	verbose(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
-
-	if (!options.verbose) loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
 
 	const blocksMap: Map<string, RemoteBlock> = (
 		await gitProviders.fetchBlocks(...resolvedRepos)

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -75,6 +75,8 @@ const _diff = async (options: Options) => {
 		}
 	}
 
+	loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
+
 	const resolvedRepos: gitProviders.ResolvedRepo[] = (
 		await gitProviders.resolvePaths(...repoPaths)
 	).match(
@@ -84,8 +86,6 @@ const _diff = async (options: Options) => {
 			program.error(color.red(message));
 		}
 	);
-
-	loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
 
 	const blocksMap: Map<string, RemoteBlock> = (
 		await gitProviders.fetchBlocks(...resolvedRepos)

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -105,6 +105,8 @@ const _update = async (blockNames: string[], options: Options) => {
 
 	verbose(`Resolving ${color.cyan(repoPaths.join(', '))}`);
 
+	if (!options.verbose) loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
+
 	const resolvedRepos: gitProviders.ResolvedRepo[] = (
 		await gitProviders.resolvePaths(...repoPaths)
 	).match(
@@ -118,8 +120,6 @@ const _update = async (blockNames: string[], options: Options) => {
 	verbose(`Resolved ${color.cyan(repoPaths.join(', '))}`);
 
 	verbose(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
-
-	if (!options.verbose) loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
 
 	const blocksMap: Map<string, RemoteBlock> = (
 		await gitProviders.fetchBlocks(...resolvedRepos)

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -19,7 +19,8 @@ export type InstallingBlock = {
 const resolveTree = async (
 	blockSpecifiers: string[],
 	blocksMap: Map<string, RemoteBlock>,
-	repoPaths: gitProviders.ResolvedRepo[]
+	repoPaths: gitProviders.ResolvedRepo[],
+	installed: Map<string, InstallingBlock> = new Map()
 ): Promise<Result<InstallingBlock[], string>> => {
 	const blocks = new Map<string, InstallingBlock>();
 
@@ -69,9 +70,10 @@ const resolveTree = async (
 
 		if (block.localDependencies && block.localDependencies.length > 0) {
 			const subDeps = await resolveTree(
-				block.localDependencies.filter((dep) => !blocks.has(dep)),
+				block.localDependencies.filter((dep) => !blocks.has(dep) && !installed.has(dep)),
 				blocksMap,
-				repoPaths
+				repoPaths,
+				blocks
 			);
 
 			if (subDeps.isErr()) return Err(subDeps.unwrapErr());


### PR DESCRIPTION
Also moves loading to the correct position on `add`, `update`, and `diff`.