### PR TITLE
feat: prune blocks, new rule, and add preview

### DIFF
--- a/.changeset/dirty-jars-film.md
+++ b/.changeset/dirty-jars-film.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Add `preview` `build` option so that you can see what users will see when running the `add` command.

--- a/.changeset/great-rules-sort.md
+++ b/.changeset/great-rules-sort.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Prune unused blocks (Not listed and not a dependency of another block).

--- a/.changeset/quick-terms-lay.md
+++ b/.changeset/quick-terms-lay.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Add `no-unused-block` rule to warn users of blocks that will be pruned.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -44,6 +44,11 @@
 				"type": "string"
 			}
 		},
+		"preview": {
+			"description": "Display a preview of the blocks list.",
+			"type": "boolean",
+			"default": false
+		},
 		"rules": {
 			"description": "Configure rules when checking manifest after build.",
 			"type": "object",
@@ -88,6 +93,12 @@
 					"type": "string",
 					"enum": ["error", "warn", "off"],
 					"default": "error"
+				},
+				"no-unused-block": {
+					"description": "Disallow unused blocks. (Not listed and not a dependency of another block)",
+					"type": "string",
+					"enum": ["error", "warn", "off"],
+					"default": "warn"
 				}
 			},
 			"default": {
@@ -95,7 +106,8 @@
 				"no-unpinned-dependency": "warn",
 				"require-local-dependency-exists": "error",
 				"max-local-dependencies": ["warn", 10],
-				"no-circular-dependency": "error"
+				"no-circular-dependency": "error",
+				"no-unused-block": "warn"
 			}
 		}
 	},

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -57,6 +57,7 @@ const registryConfigSchema = v.object({
 	doNotListBlocks: v.optional(v.array(v.string()), []),
 	doNotListCategories: v.optional(v.array(v.string()), []),
 	excludeDeps: v.optional(v.array(v.string()), []),
+	preview: v.optional(v.boolean()),
 	rules: v.optional(ruleConfigSchema),
 });
 

--- a/sites/docs/src/routes/docs/cli/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/+page.svelte
@@ -99,8 +99,8 @@ Options:
   --do-not-list-blocks [blockNames...]         The names of blocks that shouldn't be listed when the user runs add.
   --do-not-list-categories [categoryNames...]  The names of categories that shouldn't be listed when the user runs add.
   --exclude-deps [deps...]                     Dependencies that should not be added.
+  --preview                                    Display a preview of the blocks list.
   --no-output                                  Do not output a \`jsrepo-manifest.json\` file.
-  --error-on-warn                              If there is a warning throw an error and do not allow build to complete. (default: false)
   --verbose                                    Include debug logs. (default: false)
   --cwd <path>                                 The current working directory. (default: ".")
   -h, --help                                   display help for command`}

--- a/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
+++ b/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
@@ -109,6 +109,16 @@
     ]
 }`}
 />
+<SubHeading>preview</SubHeading>
+<p>
+	<CodeSpan>preview</CodeSpan> displays a preview of the blocks list.
+</p>
+<Code
+	lang="json"
+	code={`{
+    "preview": false
+}`}
+/>
 <SubHeading>rules</SubHeading>
 <p>
 	<CodeSpan>rules</CodeSpan> allows you to configure the rules when checking the manifest file after
@@ -123,7 +133,8 @@
 		"no-unpinned-dependency": "warn",
 		"require-local-dependency-exists": "error",
 		"max-local-dependencies": ["warn", 10],
-		"no-circular-dependency": "error"
+		"no-circular-dependency": "error",
+		"no-unused-block": "warn",
 	}
 }`}
 />
@@ -146,4 +157,8 @@
 <div class="flex flex-col gap-2">
 	<CodeSpan class="w-fit">no-circular-dependency</CodeSpan>
 	<p>Disallow circular dependencies.</p>
+</div>
+<div class="flex flex-col gap-2">
+	<CodeSpan class="w-fit">no-unused-block</CodeSpan>
+	<p>Disallow unused blocks. (Not listed and not a dependency of another block)</p>
 </div>


### PR DESCRIPTION
- Blocks that are not listed and not depended on by any other blocks are essentially 'dead' code that just bloats the manifest so now we remove them during the build
- Adds a `no-unused-block` rule that can be used to detect blocks that will be removed during build
- Adds a `preview` key to the build config to allow you to see what the blocks list will look like when the user runs `jsrepo add`