### PR TITLE
feat: Remember `zero-config` options

### DIFF
--- a/.changeset/heavy-birds-shake.md
+++ b/.changeset/heavy-birds-shake.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Remember `zero-config` settings for each directory and suggest the previously selected config as the default value for each prompt next time jsrepo is run.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/utils/persisted.ts
+++ b/packages/cli/src/utils/persisted.ts
@@ -1,7 +1,5 @@
 import Conf from 'conf';
 
-const get = () => {
-	return new Conf({ projectName: 'jsrepo' });
-};
+const get = () => new Conf({ projectName: 'jsrepo' });
 
 export { get };


### PR DESCRIPTION
Fixes #270 

Now when you add with no config your selections will be remembered for the next time you run jsrepo in that same directory.