### PR TITLE
feat: `no-framework-dependency` rule and `excludeBlocks` / `excludeCategories`

### DIFF
--- a/.changeset/seven-singers-carry.md
+++ b/.changeset/seven-singers-carry.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Add `no-framework-dependency` rule so that registry authors are warned if they forget to exclude framework dependencies.

--- a/.changeset/wicked-moons-rest.md
+++ b/.changeset/wicked-moons-rest.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Add `excludeBlocks` and `excludeCategories` keys to `build` config.

--- a/examples/registry/jsrepo-build-config.json
+++ b/examples/registry/jsrepo-build-config.json
@@ -2,7 +2,7 @@
 	"$schema": "https://unpkg.com/jsrepo@1.17.0/schemas/project-config.json",
 	"dirs": ["./src", "./blocks"],
 	"doNotListBlocks": [],
-	"doNotListCategories": ["utils"],
+	"doNotListCategories": [],
 	"excludeDeps": [],
 	"includeBlocks": [],
 	"includeCategories": []

--- a/examples/registry/jsrepo-build-config.json
+++ b/examples/registry/jsrepo-build-config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://unpkg.com/jsrepo@1.17.0/schemas/project-config.json",
+	"$schema": "https://unpkg.com/jsrepo@1.17.0/schemas/registry-config.json",
 	"dirs": ["./src", "./blocks"],
 	"doNotListBlocks": [],
 	"doNotListCategories": [],

--- a/examples/registry/jsrepo-manifest.json
+++ b/examples/registry/jsrepo-manifest.json
@@ -1,0 +1,130 @@
+[
+	{
+		"name": "types",
+		"blocks": [
+			{
+				"name": "index",
+				"directory": "src/types",
+				"category": "types",
+				"tests": false,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"index.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "point",
+				"directory": "src/types",
+				"category": "types",
+				"tests": false,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"point.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	},
+	{
+		"name": "utils",
+		"blocks": [
+			{
+				"name": "math",
+				"directory": "src/utils/math",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": true,
+				"list": true,
+				"files": [
+					"add.test.ts",
+					"add.ts",
+					"create-point.ts",
+					"format-answer.ts",
+					"index.ts",
+					"subtract.test.ts",
+					"subtract.ts"
+				],
+				"localDependencies": [
+					"types/point",
+					"utils/pretty-print"
+				],
+				"dependencies": [],
+				"devDependencies": [],
+				"_imports_": {
+					"../../types/point": "{{types/point}}",
+					"../pretty-print": "{{utils/pretty-print}}"
+				}
+			},
+			{
+				"name": "math-user",
+				"directory": "src/utils/math-user",
+				"category": "utils",
+				"tests": false,
+				"subdirectory": true,
+				"list": true,
+				"files": [
+					"use.ts"
+				],
+				"localDependencies": [
+					"utils/math"
+				],
+				"dependencies": [],
+				"devDependencies": [],
+				"_imports_": {
+					"$utils/math/add": "{{utils/math}}/add"
+				}
+			},
+			{
+				"name": "pretty-print",
+				"directory": "src/utils/pretty-print",
+				"category": "utils",
+				"tests": false,
+				"subdirectory": true,
+				"list": true,
+				"files": [
+					"index.ts",
+					"print.ts"
+				],
+				"localDependencies": [
+					"logging/logger"
+				],
+				"dependencies": [
+					"chalk@^5.3.0"
+				],
+				"devDependencies": [],
+				"_imports_": {
+					"$logging/logger": "{{logging/logger}}"
+				}
+			}
+		]
+	},
+	{
+		"name": "logging",
+		"blocks": [
+			{
+				"name": "logger",
+				"directory": "blocks/logging",
+				"category": "logging",
+				"tests": false,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"logger.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	}
+]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -99,6 +99,12 @@
 					"type": "string",
 					"enum": ["error", "warn", "off"],
 					"default": "warn"
+				},
+				"no-framework-dependency": {
+					"description": "Disallow frameworks (Svelte, Vue, React, etc.) as dependencies.",
+					"type": "string",
+					"enum": ["error", "warn", "off"],
+					"default": "warn"
 				}
 			},
 			"default": {
@@ -107,7 +113,8 @@
 				"require-local-dependency-exists": "error",
 				"max-local-dependencies": ["warn", 10],
 				"no-circular-dependency": "error",
-				"no-unused-block": "warn"
+				"no-unused-block": "warn",
+				"no-framework-dependency": "warn"
 			}
 		}
 	},

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -23,6 +23,20 @@
 				"type": "string"
 			}
 		},
+		"excludeBlocks": {
+			"description": "The names of the blocks that should not be included in the manifest.",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"excludeCategories": {
+			"description": "The names of the categories that should not be included in the manifest.",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
 		"doNotListBlocks": {
 			"description": "The names of blocks that shouldn't be listed when the user runs add.",
 			"type": "array",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -127,7 +127,7 @@ const _build = async (options: Options) => {
 
 	loading.start('Checking manifest');
 
-	const { warnings, errors } = runRules(categories, config.rules);
+	const { warnings, errors } = runRules(categories, config, config.rules);
 
 	loading.stop('Completed checking manifest.');
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -16,6 +16,8 @@ const schema = v.object({
 	dirs: v.optional(v.array(v.string())),
 	includeBlocks: v.optional(v.array(v.string())),
 	includeCategories: v.optional(v.array(v.string())),
+	excludeBlocks: v.optional(v.array(v.string())),
+	excludeCategories: v.optional(v.array(v.string())),
 	excludeDeps: v.optional(v.array(v.string())),
 	doNotListBlocks: v.optional(v.array(v.string())),
 	doNotListCategories: v.optional(v.array(v.string())),
@@ -34,6 +36,11 @@ const build = new Command('build')
 	.option(
 		'--include-categories [categoryNames...]',
 		'Include only the categories with these names.'
+	)
+	.option('--exclude-blocks [blockNames...]', 'Do not include the blocks with these names.')
+	.option(
+		'--exclude-categories [categoryNames...]',
+		'Do not include the categories with these names.'
 	)
 	.option(
 		'--do-not-list-blocks [blockNames...]',
@@ -74,6 +81,8 @@ const _build = async (options: Options) => {
 					excludeDeps: options.excludeDeps ?? [],
 					includeBlocks: options.includeBlocks ?? [],
 					includeCategories: options.includeCategories ?? [],
+					excludeBlocks: options.excludeBlocks ?? [],
+					excludeCategories: options.excludeCategories ?? [],
 					preview: options.preview,
 				} satisfies RegistryConfig;
 			}
@@ -88,6 +97,8 @@ const _build = async (options: Options) => {
 				mergedVal.doNotListCategories = options.doNotListCategories;
 			if (options.includeBlocks) mergedVal.includeBlocks = options.includeBlocks;
 			if (options.includeCategories) mergedVal.includeCategories = options.includeCategories;
+			if (options.excludeBlocks) mergedVal.excludeBlocks = options.excludeBlocks;
+			if (options.excludeCategories) mergedVal.excludeCategories = options.excludeCategories;
 			if (options.excludeDeps) mergedVal.excludeDeps = options.excludeDeps;
 			if (options.preview !== undefined) mergedVal.preview = options.preview;
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -352,6 +352,8 @@ const _initRegistry = async (options: Options) => {
 			excludeDeps: [],
 			includeBlocks: [],
 			includeCategories: [],
+			excludeBlocks: [],
+			excludeCategories: [],
 		};
 	}
 

--- a/packages/cli/src/utils/build/index.ts
+++ b/packages/cli/src/utils/build/index.ts
@@ -55,6 +55,8 @@ const buildBlocksDirectory = (
 			excludeDeps,
 			includeBlocks,
 			includeCategories,
+			excludeBlocks,
+			excludeCategories,
 			dirs,
 			doNotListBlocks,
 			doNotListCategories,
@@ -78,14 +80,21 @@ const buildBlocksDirectory = (
 
 		const categoryName = path.basename(categoryPath);
 
-		const shouldListCategory = doNotListCategories.findIndex((a) => a === categoryName) === -1;
-
-		// if includeCategories enabled and block is not part of includeCategories skip adding it
+		// if excludeCategories enabled and category is part of excludeCategories
 		if (
-			includeCategories.length > 0 &&
-			includeCategories.find((val) => val.trim() === categoryName.trim()) === undefined
+			excludeCategories.length > 0 &&
+			excludeCategories.find((val) => val.trim() === categoryName.trim())
 		)
 			continue;
+
+		// if includeCategories enabled and category is not part of includeCategories skip adding it
+		if (
+			includeCategories.length > 0 &&
+			!includeCategories.find((val) => val.trim() === categoryName.trim())
+		)
+			continue;
+
+		const shouldListCategory = doNotListCategories.findIndex((a) => a === categoryName) === -1;
 
 		const category: Category = {
 			name: categoryName,
@@ -104,10 +113,17 @@ const buildBlocksDirectory = (
 
 				const shouldListBlock = doNotListBlocks.findIndex((a) => a === name) === -1;
 
+				// if excludeBlocks enabled and block is part of excludeBlocks skip adding it
+				if (
+					excludeBlocks.length > 0 &&
+					excludeBlocks.find((val) => val.trim() === name.trim())
+				)
+					continue;
+
 				// if includeBlocks enabled and block is not part of includeBlocks skip adding it
 				if (
 					includeBlocks.length > 0 &&
-					includeBlocks.find((val) => val.trim() === name.trim()) === undefined
+					!includeBlocks.find((val) => val.trim() === name.trim())
 				)
 					continue;
 
@@ -169,10 +185,17 @@ const buildBlocksDirectory = (
 
 				const shouldListBlock = doNotListBlocks.findIndex((a) => a === blockName) === -1;
 
+				// if excludeBlocks enabled and block is part of excludeBlocks skip adding it
+				if (
+					excludeBlocks.length > 0 &&
+					excludeBlocks.find((val) => val.trim() === blockName.trim())
+				)
+					continue;
+
 				// if includeBlocks enabled and block is not part of includeBlocks skip adding it
 				if (
 					includeBlocks.length > 0 &&
-					includeBlocks.find((val) => val.trim() === blockName.trim()) === undefined
+					!includeBlocks.find((val) => val.trim() === blockName.trim())
 				)
 					continue;
 

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -54,6 +54,8 @@ const registryConfigSchema = v.object({
 	dirs: v.array(v.string()),
 	includeBlocks: v.optional(v.array(v.string()), []),
 	includeCategories: v.optional(v.array(v.string()), []),
+	excludeBlocks: v.optional(v.array(v.string()), []),
+	excludeCategories: v.optional(v.array(v.string()), []),
 	doNotListBlocks: v.optional(v.array(v.string()), []),
 	doNotListCategories: v.optional(v.array(v.string()), []),
 	excludeDeps: v.optional(v.array(v.string()), []),

--- a/sites/docs/src/routes/docs/cli/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/+page.svelte
@@ -96,6 +96,8 @@ Options:
   --dirs [dirs...]                             The directories containing the blocks.
   --include-blocks [blockNames...]             Include only the blocks with these names.
   --include-categories [categoryNames...]      Include only the categories with these names.
+  --exclude-blocks [blockNames...]             Do not include the blocks with these names.
+  --exclude-categories [categoryNames...]      Do not include the categories with these names.
   --do-not-list-blocks [blockNames...]         The names of blocks that shouldn't be listed when the user runs add.
   --do-not-list-categories [categoryNames...]  The names of categories that shouldn't be listed when the user runs add.
   --exclude-deps [deps...]                     Dependencies that should not be added.

--- a/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
+++ b/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
@@ -109,6 +109,32 @@
     ]
 }`}
 />
+<SubHeading>excludeBlocks</SubHeading>
+<p>
+	<CodeSpan>excludeBlocks</CodeSpan> allows you to prevent the specified blocks from being included in
+	the manifest.
+</p>
+<Code
+	lang="json"
+	code={`{
+    "excludeBlocks": [
+        "domain"
+    ]
+}`}
+/>
+<SubHeading>excludeCategories</SubHeading>
+<p>
+	<CodeSpan>excludeCategories</CodeSpan> allows you to prevent the specified categories from being included
+	in the manifest.
+</p>
+<Code
+	lang="json"
+	code={`{
+    "excludeCategories": [
+        "INTERNAL"
+    ]
+}`}
+/>
 <SubHeading>preview</SubHeading>
 <p>
 	<CodeSpan>preview</CodeSpan> displays a preview of the blocks list.
@@ -135,6 +161,7 @@
 		"max-local-dependencies": ["warn", 10],
 		"no-circular-dependency": "error",
 		"no-unused-block": "warn",
+		"no-framework-dependency": "warn",
 	}
 }`}
 />
@@ -161,4 +188,8 @@
 <div class="flex flex-col gap-2">
 	<CodeSpan class="w-fit">no-unused-block</CodeSpan>
 	<p>Disallow unused blocks. (Not listed and not a dependency of another block)</p>
+</div>
+<div class="flex flex-col gap-2">
+	<CodeSpan class="w-fit">no-framework-dependency</CodeSpan>
+	<p>Disallow frameworks (Svelte, Vue, React) as dependencies.</p>
 </div>


### PR DESCRIPTION
Fixes #274
Fixes #273 

- Adds `no-framework-dependency` rule with some initially configured frameworks
- Adds `excludeBlocks` and `excludeCategories` keys to config