### PR TITLE
feat: ensure `<script module>` in `*.svelte` files is walked for dependencies

### DIFF
--- a/.changeset/tall-rocks-pay.md
+++ b/.changeset/tall-rocks-pay.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+ensure `<script module>` dependencies are parsed in `*.svelte` files.


### PR DESCRIPTION
Found this working on `shadcn-svelte`.