### PR TITLE
fix: Resolve a few bugs with `build`

### DIFF
--- a/.changeset/cuddly-files-bathe.md
+++ b/.changeset/cuddly-files-bathe.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+ensure `build` returns the error when the extended tsconfig doesn't exist.

--- a/.changeset/early-spies-shave.md
+++ b/.changeset/early-spies-shave.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+fix stack overflow when checking for circular dependencies.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/utils/build/check.ts
+++ b/packages/cli/src/utils/build/check.ts
@@ -288,6 +288,9 @@ const searchForDep = (
 	for (const dep of block.localDependencies) {
 		if (dep === search) return newChain;
 
+		// it will be found in another pass but we don't want to get a stack overflow
+		if (chain.includes(dep)) return undefined;
+
 		const [categoryName, blockName] = dep.split('/');
 
 		const depBlock = categories


### PR DESCRIPTION
- ensure `build` returns the error when the extended tsconfig doesn't exist.
- fix stack overflow when checking for circular dependencies.