### PR TITLE
feat: `listBlocks` and `listCategories` config keys

### DIFF
--- a/.changeset/ninety-pets-shave.md
+++ b/.changeset/ninety-pets-shave.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Add `listBlocks` and `listCategories` keys to build config.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -37,15 +37,29 @@
 				"type": "string"
 			}
 		},
+		"listBlocks": {
+			"description": "List only the blocks with these names.",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
+		"listCategories": {
+			"description": "List only the categories with these names.",
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
 		"doNotListBlocks": {
-			"description": "The names of blocks that shouldn't be listed when the user runs add.",
+			"description": "Do not list the blocks with these names.",
 			"type": "array",
 			"items": {
 				"type": "string"
 			}
 		},
 		"doNotListCategories": {
-			"description": "The names of categories that shouldn't be listed when the user runs add.",
+			"description": "Do not list the categories with these names.",
 			"type": "array",
 			"items": {
 				"type": "string"

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -19,6 +19,8 @@ const schema = v.object({
 	excludeBlocks: v.optional(v.array(v.string())),
 	excludeCategories: v.optional(v.array(v.string())),
 	excludeDeps: v.optional(v.array(v.string())),
+	listBlocks: v.optional(v.array(v.string())),
+	listCategories: v.optional(v.array(v.string())),
 	doNotListBlocks: v.optional(v.array(v.string())),
 	doNotListCategories: v.optional(v.array(v.string())),
 	preview: v.optional(v.boolean()),
@@ -42,13 +44,12 @@ const build = new Command('build')
 		'--exclude-categories [categoryNames...]',
 		'Do not include the categories with these names.'
 	)
-	.option(
-		'--do-not-list-blocks [blockNames...]',
-		"The names of blocks that shouldn't be listed when the user runs add."
-	)
+	.option('--list-blocks [blockNames...]', 'List only the blocks with these names.')
+	.option('--list-categories [categoryNames...]', 'List only the categories with these names.')
+	.option('--do-not-list-blocks [blockNames...]', 'Do not list the blocks with these names.')
 	.option(
 		'--do-not-list-categories [categoryNames...]',
-		"The names of categories that shouldn't be listed when the user runs add."
+		'Do not list the categories with these names.'
 	)
 	.option('--exclude-deps [deps...]', 'Dependencies that should not be added.')
 	.option('--preview', 'Display a preview of the blocks list.')
@@ -78,6 +79,8 @@ const _build = async (options: Options) => {
 					dirs: options.dirs ?? [],
 					doNotListBlocks: options.doNotListBlocks ?? [],
 					doNotListCategories: options.doNotListCategories ?? [],
+					listBlocks: options.listBlocks ?? [],
+					listCategories: options.listCategories ?? [],
 					excludeDeps: options.excludeDeps ?? [],
 					includeBlocks: options.includeBlocks ?? [],
 					includeCategories: options.includeCategories ?? [],
@@ -95,6 +98,8 @@ const _build = async (options: Options) => {
 			if (options.doNotListBlocks) mergedVal.doNotListBlocks = options.doNotListBlocks;
 			if (options.doNotListCategories)
 				mergedVal.doNotListCategories = options.doNotListCategories;
+			if (options.listBlocks) mergedVal.listBlocks = options.listBlocks;
+			if (options.listCategories) mergedVal.listCategories = options.listCategories;
 			if (options.includeBlocks) mergedVal.includeBlocks = options.includeBlocks;
 			if (options.includeCategories) mergedVal.includeCategories = options.includeCategories;
 			if (options.excludeBlocks) mergedVal.excludeBlocks = options.excludeBlocks;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -349,11 +349,14 @@ const _initRegistry = async (options: Options) => {
 			dirs: [],
 			doNotListBlocks: [],
 			doNotListCategories: [],
+			listBlocks: [],
+			listCategories: [],
 			excludeDeps: [],
 			includeBlocks: [],
 			includeCategories: [],
 			excludeBlocks: [],
 			excludeCategories: [],
+			preview: false,
 		};
 	}
 

--- a/packages/cli/src/utils/build/index.ts
+++ b/packages/cli/src/utils/build/index.ts
@@ -6,7 +6,7 @@ import * as v from 'valibot';
 import * as ascii from '../ascii';
 import type { RegistryConfig } from '../config';
 import { languages } from '../language-support';
-import { isDependedOn, searchForDep } from './check';
+import { isDependedOn } from './check';
 
 export const blockSchema = v.object({
 	name: v.string(),
@@ -60,6 +60,8 @@ const buildBlocksDirectory = (
 			dirs,
 			doNotListBlocks,
 			doNotListCategories,
+			listBlocks,
+			listCategories,
 		},
 	}: Options
 ): Category[] => {
@@ -94,7 +96,15 @@ const buildBlocksDirectory = (
 		)
 			continue;
 
-		const shouldListCategory = doNotListCategories.findIndex((a) => a === categoryName) === -1;
+		let shouldListCategory = true;
+
+		if (doNotListCategories.includes(categoryName)) {
+			shouldListCategory = false;
+		}
+
+		if (listCategories.length > 0 && !listCategories.includes(categoryName)) {
+			shouldListCategory = false;
+		}
 
 		const category: Category = {
 			name: categoryName,
@@ -111,7 +121,15 @@ const buildBlocksDirectory = (
 
 				const name = path.parse(path.basename(file)).name;
 
-				const shouldListBlock = doNotListBlocks.findIndex((a) => a === name) === -1;
+				let shouldListBlock = true;
+
+				if (doNotListBlocks.includes(name)) {
+					shouldListBlock = false;
+				}
+
+				if (listBlocks.length > 0 && !listBlocks.includes(name)) {
+					shouldListBlock = false;
+				}
 
 				// if excludeBlocks enabled and block is part of excludeBlocks skip adding it
 				if (
@@ -183,7 +201,15 @@ const buildBlocksDirectory = (
 			} else {
 				const blockName = file;
 
-				const shouldListBlock = doNotListBlocks.findIndex((a) => a === blockName) === -1;
+				let shouldListBlock = true;
+
+				if (doNotListBlocks.includes(blockName)) {
+					shouldListBlock = false;
+				}
+
+				if (listBlocks.length > 0 && !listBlocks.includes(blockName)) {
+					shouldListBlock = false;
+				}
 
 				// if excludeBlocks enabled and block is part of excludeBlocks skip adding it
 				if (

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -58,6 +58,8 @@ const registryConfigSchema = v.object({
 	excludeCategories: v.optional(v.array(v.string()), []),
 	doNotListBlocks: v.optional(v.array(v.string()), []),
 	doNotListCategories: v.optional(v.array(v.string()), []),
+	listBlocks: v.optional(v.array(v.string()), []),
+	listCategories: v.optional(v.array(v.string()), []),
 	excludeDeps: v.optional(v.array(v.string()), []),
 	preview: v.optional(v.boolean()),
 	rules: v.optional(ruleConfigSchema),

--- a/sites/docs/src/routes/docs/cli/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/+page.svelte
@@ -99,8 +99,10 @@ Options:
   --include-categories [categoryNames...]      Include only the categories with these names.
   --exclude-blocks [blockNames...]             Do not include the blocks with these names.
   --exclude-categories [categoryNames...]      Do not include the categories with these names.
-  --do-not-list-blocks [blockNames...]         The names of blocks that shouldn't be listed when the user runs add.
-  --do-not-list-categories [categoryNames...]  The names of categories that shouldn't be listed when the user runs add.
+  --list-blocks [blockNames...]                List only the blocks with these names.
+  --list-categories [categoryNames...]         List only the categories with these names.
+  --do-not-list-blocks [blockNames...]         Do not list the blocks with these names.
+  --do-not-list-categories [categoryNames...]  Do not list the categories with these names.
   --exclude-deps [deps...]                     Dependencies that should not be added.
   --preview                                    Display a preview of the blocks list.
   --no-output                                  Do not output a \`jsrepo-manifest.json\` file.

--- a/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
+++ b/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
@@ -39,6 +39,32 @@
     ]
 }`}
 />
+<SubHeading>listBlocks</SubHeading>
+<p>
+	<CodeSpan>listBlocks</CodeSpan> is a list of block names that should be listed when the user runs the
+	<CodeSpan>add</CodeSpan> command.
+</p>
+<Code
+	lang="json"
+	code={`{
+    "listBlocks": [
+        "utils"
+    ]
+}`}
+/>
+<SubHeading>listCategories</SubHeading>
+<p>
+	<CodeSpan>listCategories</CodeSpan> is a list of category names that should be listed when the user
+	runs the <CodeSpan>add</CodeSpan> command.
+</p>
+<Code
+	lang="json"
+	code={`{
+    "listCategories": [
+        "utils"
+    ]
+}`}
+/>
 <SubHeading>doNotListBlocks</SubHeading>
 <p>
 	<CodeSpan>doNotListBlocks</CodeSpan> is a list of block names that shouldn't be listed when the user


### PR DESCRIPTION
The `listBlocks` and `listCategories` build config keys give you more fine grained control over what exactly the user sees when running add.