### PR TITLE
feat: Resolve `re-exported` dependencies

### DIFF
--- a/.changeset/plenty-penguins-invent.md
+++ b/.changeset/plenty-penguins-invent.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Resolve modules from re-exports in `*.svelte` and `*.(js|ts|jsx|tsx)` files.

--- a/examples/registry/jsrepo-manifest.json
+++ b/examples/registry/jsrepo-manifest.json
@@ -1,5 +1,29 @@
 [
 	{
+		"name": "components",
+		"blocks": [
+			{
+				"name": "button",
+				"directory": "src/components",
+				"category": "components",
+				"tests": false,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"button.svelte"
+				],
+				"localDependencies": [
+					"types/point"
+				],
+				"_imports_": {
+					"../types/point": "{{types/point}}"
+				},
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	},
+	{
 		"name": "types",
 		"blocks": [
 			{
@@ -12,8 +36,12 @@
 				"files": [
 					"index.ts"
 				],
-				"localDependencies": [],
-				"_imports_": {},
+				"localDependencies": [
+					"types/point"
+				],
+				"_imports_": {
+					"./point": "{{types/point}}"
+				},
 				"dependencies": [],
 				"devDependencies": []
 			},

--- a/examples/registry/src/components/button.svelte
+++ b/examples/registry/src/components/button.svelte
@@ -1,0 +1,5 @@
+<script module>
+    export * from "../types/point"
+    export { Point } from "../types/point"
+    export { default } from "../types/point"
+</script>

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",


### PR DESCRIPTION
Previously we only resolved dependencies that came from imports. This PR adds the ability for us to resolve modules that are used in `re-exports`.