### PR TITLE
fix: Revert change to `.svelte.(js|ts)` block names

### DIFF
--- a/.changeset/late-cows-give.md
+++ b/.changeset/late-cows-give.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Revert 75b15a6: Remove `.svelte` from block names when the block is a file that ends with `.svelte.(js|ts)`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/utils/build/index.ts
+++ b/packages/cli/src/utils/build/index.ts
@@ -326,10 +326,11 @@ const buildBlocksDirectory = (
 
 /** Takes the given file and returns the block name */
 const transformBlockName = (file: string) => {
+	// DO NOT enable until resolution is fixed
 	// custom transform for `.svelte.(js|ts)` files to drop the `.svelte` as well
-	if (file.endsWith('.svelte.ts') || file.endsWith('.svelte.js')) {
-		return file.slice(0, file.length - 10);
-	}
+	// if (file.endsWith('.svelte.ts') || file.endsWith('.svelte.js')) {
+	// 	return file.slice(0, file.length - 10);
+	// }
 
 	return path.parse(path.basename(file)).name;
 };


### PR DESCRIPTION
Unfortunately I didn't realize everything this would effect. I still want to make this happen but it's going to take more work so I will just revert it in the mean time.