### PR TITLE
fix: Fix `test` command on linux

### DIFF
--- a/.changeset/young-monkeys-smile.md
+++ b/.changeset/young-monkeys-smile.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Fix an issue where the `test` command would fail when running tests on linux.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -332,22 +332,16 @@ const _test = async (blockNames: string[], options: Options) => {
 		program.error(color.red(`Could not resolve add command for '${pm.agent}'.`));
 	}
 
-	const { command, args } = resolved;
+	const testCommand = `${resolved.command} ${resolved.args.join(' ')}`;
 
-	const testCommand = `${command} ${args.join(' ')}`;
-
-	const testingProcess = execa({
-		cwd: options.cwd,
-		stdio: ['ignore', 'pipe', 'pipe'],
-	})`${testCommand}`;
-
-	const handler = (data: string) => console.info(data.toString());
-
-	testingProcess.stdout.on('data', handler);
-	testingProcess.stderr.on('data', handler);
+	verbose(`Running ${color.cyan(testCommand)} on ${color.cyan(options.cwd)}`);
 
 	try {
-		await testingProcess;
+		await execa(resolved.command, resolved.args, {
+			cwd: options.cwd,
+			stdin: process.stdin,
+			stdout: process.stdout,
+		});
 
 		cleanUp();
 	} catch (err) {


### PR DESCRIPTION
Fixes #325 

This was a frustrating one as it was something to do with the way that execa was parsing the raw string command. 

In any case it should've been setup this way from the beginning.