### PR TITLE
fix: Ensure local dependencies are resolved correctly when files are named like `bar.svelte.ts`

### DIFF
--- a/.changeset/real-waves-smile.md
+++ b/.changeset/real-waves-smile.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Ensure imports like `foo.svelte` are resolved properly when the real path is `foo.svelte.ts`.

--- a/.changeset/thick-fans-bathe.md
+++ b/.changeset/thick-fans-bathe.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Fix an issue where resolved file extensions were left on the import even though not provided by the user.

--- a/examples/registry/blocks/svelte/component.svelte
+++ b/examples/registry/blocks/svelte/component.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+    import { THING } from "$svelte/test.svelte"
+    import { THING2 } from "$svelte/test.js"
+
+    console.log(THING);
+    console.log(THING2);
+</script>

--- a/examples/registry/blocks/svelte/test.js
+++ b/examples/registry/blocks/svelte/test.js
@@ -1,0 +1,1 @@
+export const THING2 = 1;

--- a/examples/registry/blocks/svelte/test.svelte.ts
+++ b/examples/registry/blocks/svelte/test.svelte.ts
@@ -1,0 +1,1 @@
+export const THING = "thing";

--- a/examples/registry/jsrepo-manifest.json
+++ b/examples/registry/jsrepo-manifest.json
@@ -222,6 +222,62 @@
 		]
 	},
 	{
+		"name": "svelte",
+		"blocks": [
+			{
+				"name": "component",
+				"directory": "blocks/svelte",
+				"category": "svelte",
+				"tests": false,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"component.svelte"
+				],
+				"localDependencies": [
+					"svelte/test.svelte",
+					"svelte/test"
+				],
+				"_imports_": {
+					"$svelte/test.svelte": "{{svelte/test.svelte}}",
+					"$svelte/test.js": "{{svelte/test}}.js"
+				},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "test",
+				"directory": "blocks/svelte",
+				"category": "svelte",
+				"tests": false,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"test.js"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "test.svelte",
+				"directory": "blocks/svelte",
+				"category": "svelte",
+				"tests": false,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"test.svelte.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	},
+	{
 		"name": "vue",
 		"blocks": [
 			{

--- a/examples/registry/tsconfig.json
+++ b/examples/registry/tsconfig.json
@@ -12,6 +12,7 @@
 			"$types/*": ["./src/types/*"],
 			"$utils/*": ["./src/utils/*"],
 			"$logging/*": ["./blocks/logging/*"],
+			"$svelte/*": ["./blocks/svelte/*"]
 		}
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,7 +61,7 @@
 		"pathe": "^2.0.0",
 		"prettier": "^3.4.2",
 		"semver": "^7.6.3",
-		"svelte": "^5.16.5",
+		"svelte": "^5.17.0",
 		"ts-morph": "^25.0.0",
 		"valibot": "1.0.0-beta.11",
 		"validate-npm-package-name": "^6.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/utils/language-support.ts
+++ b/packages/cli/src/utils/language-support.ts
@@ -557,10 +557,18 @@ const resolveLocalImport = (
 	isSubDir: boolean,
 	{
 		filePath,
+		dropExtension = true,
 		alias,
 		dirs,
 		cwd,
-	}: { filePath: string; dirs: string[]; alias?: string; modIsFile?: boolean; cwd: string }
+	}: {
+		filePath: string;
+		dirs: string[];
+		alias?: string;
+		modIsFile?: boolean;
+		cwd: string;
+		dropExtension?: boolean;
+	}
 ): Result<ResolveLocalImportResult | undefined, string> => {
 	if (isSubDir && (mod.startsWith('./') || mod === '.')) return Ok(undefined);
 
@@ -573,17 +581,17 @@ const resolveLocalImport = (
 	// get the full path to the current category containing folder
 	const fullDir = path.join(categoryDir, '../');
 
-	// mod paths that reference outside of the current blocks directory are invalid unless it's an alias
 	if (modPath.startsWith(fullDir)) {
-		return Ok(parsePath(modPath.slice(fullDir.length)));
+		return Ok(parsePath(modPath.slice(fullDir.length), dropExtension));
 	}
 
 	if (alias) {
 		for (const dir of dirs) {
 			const containingPath = path.resolve(path.join(cwd, dir));
 			const absPath = path.resolve(modPath);
+
 			if (absPath.startsWith(containingPath)) {
-				return Ok(parsePath(absPath.slice(containingPath.length + 1)));
+				return Ok(parsePath(absPath.slice(containingPath.length + 1), dropExtension));
 			}
 		}
 
@@ -597,7 +605,7 @@ const resolveLocalImport = (
 	);
 };
 
-const parsePath = (localPath: string): ResolveLocalImportResult => {
+const parsePath = (localPath: string, dropExtension = true): ResolveLocalImportResult => {
 	let [category, block, ...rest] = localPath.split('/');
 
 	// if undefined we assume we are pointing to the index file
@@ -608,7 +616,7 @@ const parsePath = (localPath: string): ResolveLocalImportResult => {
 	let trimmedBlock = block;
 
 	// remove file extension
-	if (trimmedBlock.includes('.')) {
+	if (dropExtension && trimmedBlock.includes('.')) {
 		trimmedBlock = trimmedBlock.slice(
 			0,
 			trimmedBlock.length - path.parse(trimmedBlock).ext.length
@@ -665,14 +673,18 @@ const tryResolveLocalAlias = (
 
 			if (!foundMod) continue;
 
-			const relativeSolved = path.relative(
+			const pathResolved = path.relative(
 				path.resolve(path.join(filePath, '../')),
-				foundMod.path
+				foundMod.prettyPath
 			);
 
-			const localDep = resolveLocalImport(relativeSolved, isSubDir, {
+			// if it is not equal the extension has already been dropped
+			const shouldDropExtension = foundMod.prettyPath === foundMod.path;
+
+			const localDep = resolveLocalImport(pathResolved, isSubDir, {
 				filePath,
 				alias: mod,
+				dropExtension: shouldDropExtension,
 				dirs,
 				cwd,
 				modIsFile: foundMod.type === 'file',
@@ -695,43 +707,44 @@ const tryResolveLocalAlias = (
  */
 const searchForModule = (
 	modPath: string
-): { path: string; type: 'file' | 'directory' } | undefined => {
+): { path: string; prettyPath: string; type: 'file' | 'directory' } | undefined => {
 	if (fs.existsSync(modPath)) {
-		return { path: modPath, type: fs.statSync(modPath).isDirectory() ? 'directory' : 'file' };
-	}
-
-	const extension = path.parse(modPath).ext;
-
-	// sometimes it will point to .js because it will resolve in prod but not for us
-	if (extension === '.js') {
-		const newPath = `${modPath.slice(0, modPath.length - 3)}.ts`;
-
-		if (fs.existsSync(newPath)) return { path: modPath, type: 'file' };
+		return {
+			path: modPath,
+			prettyPath: modPath,
+			type: fs.statSync(modPath).isDirectory() ? 'directory' : 'file',
+		};
 	}
 
 	const containing = path.join(modPath, '../');
 
-	// open containing folder
+	// if containing folder doesn't exist this can't exist
 	if (!fs.existsSync(containing)) return undefined;
+
+	// sometimes it will point to .js because it will resolve in prod but not for us
+	if (modPath.endsWith('.js')) {
+		const newPath = `${modPath.slice(0, modPath.length - 3)}.ts`;
+
+		if (fs.existsSync(newPath)) return { path: newPath, prettyPath: modPath, type: 'file' };
+	}
 
 	const files = fs.readdirSync(containing);
 
+	const modParsed = path.parse(modPath);
+
 	for (const file of files) {
-		const fileWithoutExtension = path.parse(file).name;
+		const fileParsed = path.parse(file);
 
 		// this way the extension doesn't matter
-		if (fileWithoutExtension === path.basename(modPath)) {
+		if (fileParsed.name === modParsed.base) {
 			const filePath = path.join(containing, file);
 
-			let normalizedFile = filePath;
-
-			// in this case the .ts extension was obviously not intended
-			if (normalizedFile.endsWith('.ts')) {
-				normalizedFile = normalizedFile.slice(0, normalizedFile.length - 3);
-			}
+			// we remove the extension since it wasn't included by the user
+			const prettyPath = filePath.slice(0, filePath.length - fileParsed.ext.length);
 
 			return {
-				path: normalizedFile,
+				path: filePath,
+				prettyPath: prettyPath,
 				type: fs.statSync(filePath).isDirectory() ? 'directory' : 'file',
 			};
 		}

--- a/packages/cli/src/utils/language-support.ts
+++ b/packages/cli/src/utils/language-support.ts
@@ -721,16 +721,16 @@ const searchForModule = (
 	// if containing folder doesn't exist this can't exist
 	if (!fs.existsSync(containing)) return undefined;
 
+	const modParsed = path.parse(modPath);
+
 	// sometimes it will point to .js because it will resolve in prod but not for us
-	if (modPath.endsWith('.js')) {
+	if (modParsed.ext === '.js') {
 		const newPath = `${modPath.slice(0, modPath.length - 3)}.ts`;
 
 		if (fs.existsSync(newPath)) return { path: newPath, prettyPath: modPath, type: 'file' };
 	}
 
 	const files = fs.readdirSync(containing);
-
-	const modParsed = path.parse(modPath);
 
 	for (const file of files) {
 		const fileParsed = path.parse(file);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^7.6.3
         version: 7.6.3
       svelte:
-        specifier: ^5.16.5
-        version: 5.16.5
+        specifier: ^5.17.0
+        version: 5.17.0
       ts-morph:
         specifier: ^25.0.0
         version: 25.0.0
@@ -2968,8 +2968,8 @@ packages:
     resolution: {integrity: sha512-FsA1OjAKMAFSDob6j/Tv2ZV9rY4SeqPd1WXQlQkFkePAozSHLp6tbkU9qa1xJ+uTRzMSM2Vx3USdsYZBXd3H3g==}
     engines: {node: '>=18'}
 
-  svelte@5.16.5:
-    resolution: {integrity: sha512-zTG45crJUGjNYQgmQ0YDxFJ7ge1O6ZwevPxGgGOxuMOXOQhcH9LC9GEx2JS9/BlkhxdsO8ETofQ76ouFwDVpCQ==}
+  svelte@5.17.0:
+    resolution: {integrity: sha512-0DX6fZ6R3eNDCQynmOm32vN0ErbupGl23c6hWc45KIwq9cSEIOKh6xGFuXcYVjU5fU9MLZx1+oQI1miZxmx4Tg==}
     engines: {node: '>=18'}
 
   tailwind-merge@2.6.0:
@@ -6186,7 +6186,7 @@ snapshots:
       magic-string: 0.30.15
       zimmerframe: 1.1.2
 
-  svelte@5.16.5:
+  svelte@5.17.0:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0


### PR DESCRIPTION
Fixes #340 

Previously if you had a file `bar.svelte.ts` you had to add the `.js / .ts` extension on the end of your import for `jsrepo` to correctly resolve it.

This PR fixes the resolution so that you can simply import from `bar.svelte` instead of `bar.svelte.js`.

For an example of this issue you can see: 
https://github.com/ieedan/shadcn-svelte-extras/blob/main/src/lib/components/ui/chat/chat-list.svelte#L7