### PR TITLE
fix: Use `add` instead of `install` for `package-manager-detector` when installing dependencies

### DIFF
--- a/.changeset/funny-schools-mate.md
+++ b/.changeset/funny-schools-mate.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Use `add` instead of `install` for `package-manager-detector` when installing dependencies.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -655,7 +655,7 @@ const _add = async (blockNames: string[], options: Options) => {
 
 		if (!install) {
 			if (deps.size > 0) {
-				const cmd = resolveCommand(pm, 'install', [...deps]);
+				const cmd = resolveCommand(pm, 'add', [...deps]);
 
 				steps.push(
 					`Install dependencies \`${color.cyan(`${cmd?.command} ${cmd?.args.join(' ')}`)}\``
@@ -663,7 +663,7 @@ const _add = async (blockNames: string[], options: Options) => {
 			}
 
 			if (devDeps.size > 0) {
-				const cmd = resolveCommand(pm, 'install', [...devDeps, '-D']);
+				const cmd = resolveCommand(pm, 'add', [...devDeps, '-D']);
 
 				steps.push(
 					`Install dev dependencies \`${color.cyan(`${cmd?.command} ${cmd?.args.join(' ')}`)}\``

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -566,7 +566,7 @@ const _initRegistry = async (options: Options) => {
 	let steps: string[] = [];
 
 	if (!installed && installAsDevDependency) {
-		const cmd = resolveCommand(pm, 'install', ['jsrepo', '-D']);
+		const cmd = resolveCommand(pm, 'add', ['jsrepo', '-D']);
 
 		steps.push(
 			`Install ${ascii.JSREPO} as a dev dependency \`${color.cyan(`${cmd?.command} ${cmd?.args.join(' ')}`)}\``

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -460,7 +460,7 @@ const _update = async (blockNames: string[], options: Options) => {
 
 		if (!install) {
 			if (deps.size > 0) {
-				const cmd = resolveCommand(pm, 'install', [...deps]);
+				const cmd = resolveCommand(pm, 'add', [...deps]);
 
 				steps.push(
 					`Install dependencies \`${color.cyan(`${cmd?.command} ${cmd?.args.join(' ')}`)}\``
@@ -468,7 +468,7 @@ const _update = async (blockNames: string[], options: Options) => {
 			}
 
 			if (devDeps.size > 0) {
-				const cmd = resolveCommand(pm, 'install', [...devDeps, '-D']);
+				const cmd = resolveCommand(pm, 'add', [...devDeps, '-D']);
 
 				steps.push(
 					`Install dev dependencies \`${color.cyan(`${cmd?.command} ${cmd?.args.join(' ')}`)}\``

--- a/packages/cli/src/utils/dependencies.ts
+++ b/packages/cli/src/utils/dependencies.ts
@@ -39,7 +39,7 @@ const installDependencies = async ({
 		args.push(noWorkspace);
 	}
 
-	const add = resolveCommand(pm, 'install', args);
+	const add = resolveCommand(pm, 'add', args);
 
 	if (add == null) return Err(color.red(`Could not resolve add command for '${pm}'.`));
 


### PR DESCRIPTION
Fixes an issue with yarn. This might help speed up installs too so that would be cool.