### PR TITLE
feat: Allow hosting a registry on an arbitrary url

### DIFF
--- a/.changeset/clever-waves-sort.md
+++ b/.changeset/clever-waves-sort.md
@@ -2,4 +2,4 @@
 "jsrepo": minor
 ---
 
-Add support for registries served from a custom url.
+Support for self-hosted registries. 🎉

--- a/.changeset/clever-waves-sort.md
+++ b/.changeset/clever-waves-sort.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Add support for registries served from a custom url.

--- a/.changeset/cyan-suns-fold.md
+++ b/.changeset/cyan-suns-fold.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Add tests for `add` and `build` commands.

--- a/.changeset/serious-starfishes-smell.md
+++ b/.changeset/serious-starfishes-smell.md
@@ -2,4 +2,4 @@
 "jsrepo": patch
 ---
 
-When adding with zero-config you will now be prompted to overwrite blocks if they already exist at the provided path.
+When adding blocks with zero-config you will now be prompted before overwriting an existing block

--- a/.changeset/serious-starfishes-smell.md
+++ b/.changeset/serious-starfishes-smell.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+When adding with zero-config you will now be prompted to overwrite blocks if they already exist at the provided path.

--- a/.changeset/soft-points-shop.md
+++ b/.changeset/soft-points-shop.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+Add `outputDir` config key to allow copying the registry to a different location on build. Useful for hosting registries on your own domain.

--- a/.changeset/spicy-bottles-agree.md
+++ b/.changeset/spicy-bottles-agree.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+When supplying a fully qualified block while using a config. Repos in the config are no longer fetched unless necessary.

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -2,3 +2,6 @@ node_modules
 
 # out
 dist
+
+# testing
+temp-test

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,7 +34,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@types/diff": "^7.0.0",
-		"@types/node": "^22.10.5",
+		"@types/node": "^22.10.7",
 		"@types/semver": "^7.5.8",
 		"@types/validate-npm-package-name": "^4.0.2",
 		"tsup": "^8.3.5",
@@ -61,7 +61,7 @@
 		"pathe": "^2.0.1",
 		"prettier": "^3.4.2",
 		"semver": "^7.6.3",
-		"svelte": "^5.17.5",
+		"svelte": "^5.18.0",
 		"ts-morph": "^25.0.0",
 		"valibot": "1.0.0-beta.11",
 		"validate-npm-package-name": "^6.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -9,6 +9,10 @@
 				"type": "string"
 			}
 		},
+		"outputDir": {
+			"description": "The directory to output the registry to. (Copies jsrepo-manifest.json + all required files)",
+			"default": "./"
+		},
 		"includeBlocks": {
 			"description": "The names of the blocks that should be included in the manifest.",
 			"type": "array",

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -11,7 +11,7 @@
 		},
 		"outputDir": {
 			"description": "The directory to output the registry to. (Copies jsrepo-manifest.json + all required files)",
-			"default": "./"
+			"type": "string"
 		},
 		"includeBlocks": {
 			"description": "The names of the blocks that should be included in the manifest.",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -243,9 +243,7 @@ const _add = async (blockNames: string[], options: Options) => {
 
 	verbose(`Retrieved blocks from ${color.cyan(repoPaths.join(', '))}`);
 
-	const installedBlocks = getInstalled(blocksMap, config, options.cwd).map(
-		(val) => val.specifier
-	);
+	let installedBlocks = getInstalled(blocksMap, config, options.cwd).map((val) => val.specifier);
 
 	let installingBlockNames = blockNames;
 
@@ -398,6 +396,9 @@ const _add = async (blockNames: string[], options: Options) => {
 		}
 
 		store.set(zeroConfigKey, config);
+
+		// re-run to get installed blocks at the provided path
+		installedBlocks = getInstalled(blocksMap, config, options.cwd).map((val) => val.specifier);
 	}
 
 	const { prettierOptions, biomeOptions } = await loadFormatterConfig({

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -40,7 +40,7 @@ import {
 	runTasksConcurrently,
 	truncatedList,
 } from '../utils/prompts';
-import * as gitProviders from '../utils/providers';
+import * as providers from '../utils/providers';
 
 const schema = v.object({
 	repo: v.optional(v.string()),
@@ -73,7 +73,7 @@ const add = new Command('add')
 		outro(color.green('All done!'));
 	});
 
-type RemoteBlock = Block & { sourceRepo: gitProviders.Info };
+type RemoteBlock = Block & { sourceRepo: providers.Info };
 
 const _add = async (blockNames: string[], options: Options) => {
 	const verbose = (msg: string) => {
@@ -140,7 +140,7 @@ const _add = async (blockNames: string[], options: Options) => {
 
 	// resolve repos for blocks
 	for (const blockSpecifier of blockNames) {
-		const provider = gitProviders.providers.find((p) => blockSpecifier.startsWith(p.name()));
+		const provider = providers.providers.find((p) => blockSpecifier.startsWith(p.name()));
 
 		// we are only getting repos for blocks that specified repos
 		if (!provider) {
@@ -215,8 +215,8 @@ const _add = async (blockNames: string[], options: Options) => {
 
 	if (!options.verbose) loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
 
-	const resolvedRepos: gitProviders.ResolvedRepo[] = (
-		await gitProviders.resolvePaths(...repoPaths)
+	const resolvedRepos: providers.ResolvedRepo[] = (
+		await providers.resolvePaths(...repoPaths)
 	).match(
 		(val) => val,
 		({ repo, message }) => {
@@ -230,7 +230,7 @@ const _add = async (blockNames: string[], options: Options) => {
 	verbose(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
 
 	const blocksMap: Map<string, RemoteBlock> = (
-		await gitProviders.fetchBlocks(...resolvedRepos)
+		await providers.fetchBlocks(...resolvedRepos)
 	).match(
 		(val) => val,
 		({ repo, message }) => {

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -175,7 +175,7 @@ const _add = async (blockNames: string[], options: Options) => {
 		mustResolveRepos.add(repo);
 	}
 
-	if (!resolveAllRepos) {
+	if (!resolveAllRepos && blockNames.length > 0) {
 		repoPaths = Array.from(mustResolveRepos);
 	}
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -31,7 +31,6 @@ import { installDependencies } from '../utils/dependencies';
 import { transformRemoteContent } from '../utils/files';
 import { loadFormatterConfig } from '../utils/format';
 import { getWatermark } from '../utils/get-watermark';
-import * as gitProviders from '../utils/git-providers';
 import { returnShouldInstall } from '../utils/package';
 import * as persisted from '../utils/persisted';
 import {
@@ -41,6 +40,7 @@ import {
 	runTasksConcurrently,
 	truncatedList,
 } from '../utils/prompts';
+import * as gitProviders from '../utils/providers';
 
 const schema = v.object({
 	repo: v.optional(v.string()),
@@ -130,26 +130,31 @@ const _add = async (blockNames: string[], options: Options) => {
 	}
 
 	let repoPaths = config.repos;
+	const mustResolveRepos = new Set<string>();
+	let resolveAllRepos = false;
 
 	// we just want to override all others if supplied via the CLI
-	if (options.repo) repoPaths = [options.repo];
+	if (options.repo) {
+		repoPaths = [options.repo];
+	}
 
 	// resolve repos for blocks
 	for (const blockSpecifier of blockNames) {
+		const provider = gitProviders.providers.find((p) => blockSpecifier.startsWith(p.name()));
+
 		// we are only getting repos for blocks that specified repos
-		if (!gitProviders.providers.find((p) => blockSpecifier.startsWith(p.name()))) continue;
-
-		const [providerName, owner, repoName, ...rest] = blockSpecifier.split('/');
-
-		let repo: string;
-		// if rest is greater than 2 it isn't the block specifier so it is part of the path
-		if (rest.length > 2) {
-			repo = `${providerName}/${owner}/${repoName}/${rest.slice(0, rest.length - 2).join('/')}`;
-		} else {
-			repo = `${providerName}/${owner}/${repoName}`;
+		if (!provider) {
+			// if a block doesn't specify a repo we must resolve all
+			resolveAllRepos = true;
+			continue;
 		}
 
-		if (!repoPaths.find((repoPath) => repoPath === repo)) {
+		const [repo] = provider.parseBlockSpecifier(blockSpecifier);
+
+		const alreadyExists =
+			!config.repos.find((repoPath) => repoPath === repo) && !mustResolveRepos.has(repo);
+
+		if (!alreadyExists) {
 			if (!options.allow) {
 				const result = await confirm({
 					message: `Allow ${ascii.JSREPO} to download and run code from ${color.cyan(repo)}?`,
@@ -162,8 +167,16 @@ const _add = async (blockNames: string[], options: Options) => {
 				}
 			}
 
+			// only add if it doesn't exist
 			repoPaths.push(repo);
 		}
+
+		// this way we add the config.repos as well
+		mustResolveRepos.add(repo);
+	}
+
+	if (!resolveAllRepos) {
+		repoPaths = Array.from(mustResolveRepos);
 	}
 
 	if (!options.allow && options.repo) {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -4,9 +4,9 @@ import { Command, Option } from 'commander';
 import * as v from 'valibot';
 import { context } from '../cli';
 import * as ascii from '../utils/ascii';
-import { providers } from '../utils/git-providers';
 import * as persisted from '../utils/persisted';
 import { intro } from '../utils/prompts';
+import { providers } from '../utils/providers';
 
 const schema = v.object({
 	token: v.optional(v.string()),

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -6,7 +6,7 @@ import { context } from '../cli';
 import * as ascii from '../utils/ascii';
 import * as persisted from '../utils/persisted';
 import { intro } from '../utils/prompts';
-import { providers } from '../utils/providers';
+import { http, providers } from '../utils/providers';
 
 const schema = v.object({
 	token: v.optional(v.string()),
@@ -16,12 +16,14 @@ const schema = v.object({
 
 type Options = v.InferInput<typeof schema>;
 
+const authProviders = providers.filter((p) => p.name() !== http.name());
+
 const auth = new Command('auth')
 	.description('Provide a token for access to private repositories.')
 	.option('--token <token>', 'The token to use for authenticating to your provider.')
 	.addOption(
 		new Option('--provider <name>', 'The provider this token belongs to.').choices(
-			providers.map((provider) => provider.name())
+			authProviders.map((provider) => provider.name())
 		)
 	)
 	.option('--logout', 'Erase tokens from each provider from storage.', false)
@@ -39,7 +41,7 @@ const _auth = async (options: Options) => {
 	const storage = persisted.get();
 
 	if (options.logout) {
-		for (const provider of providers) {
+		for (const provider of authProviders) {
 			const tokenKey = `${provider.name()}-token`;
 
 			if (storage.get(tokenKey) === undefined) {
@@ -69,14 +71,14 @@ const _auth = async (options: Options) => {
 		return;
 	}
 
-	if (providers.length > 1) {
+	if (authProviders.length > 1) {
 		const response = await select({
 			message: 'Which provider is this token for?',
-			options: providers.map((provider) => ({
+			options: authProviders.map((provider) => ({
 				label: provider.name(),
 				value: provider.name(),
 			})),
-			initialValue: providers[0].name(),
+			initialValue: authProviders[0].name(),
 		});
 
 		if (isCancel(response)) {
@@ -86,7 +88,7 @@ const _auth = async (options: Options) => {
 
 		options.provider = response;
 	} else {
-		options.provider = providers[0].name();
+		options.provider = authProviders[0].name();
 	}
 
 	if (options.token === undefined) {

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -14,6 +14,7 @@ import { intro } from '../utils/prompts';
 
 const schema = v.object({
 	dirs: v.optional(v.array(v.string())),
+	outputDir: v.optional(v.string()),
 	includeBlocks: v.optional(v.array(v.string())),
 	includeCategories: v.optional(v.array(v.string())),
 	excludeBlocks: v.optional(v.array(v.string())),
@@ -34,6 +35,10 @@ type Options = v.InferInput<typeof schema>;
 const build = new Command('build')
 	.description(`Builds the provided --dirs in the project root into a \`${OUTPUT_FILE}\` file.`)
 	.option('--dirs [dirs...]', 'The directories containing the blocks.')
+	.option(
+		'--output-dir <dir>',
+		'The directory to output the registry to. (Copies jsrepo-manifest.json + all required files)'
+	)
 	.option('--include-blocks [blockNames...]', 'Include only the blocks with these names.')
 	.option(
 		'--include-categories [categoryNames...]',
@@ -77,6 +82,7 @@ const _build = async (options: Options) => {
 				return {
 					$schema: '',
 					dirs: options.dirs ?? [],
+					outputDir: options.outputDir,
 					doNotListBlocks: options.doNotListBlocks ?? [],
 					doNotListCategories: options.doNotListCategories ?? [],
 					listBlocks: options.listBlocks ?? [],
@@ -95,6 +101,7 @@ const _build = async (options: Options) => {
 			// overwrites config with flag values
 
 			if (options.dirs) mergedVal.dirs = options.dirs;
+			if (options.outputDir) mergedVal.outputDir = options.outputDir;
 			if (options.doNotListBlocks) mergedVal.doNotListBlocks = options.doNotListBlocks;
 			if (options.doNotListCategories)
 				mergedVal.doNotListCategories = options.doNotListCategories;
@@ -114,14 +121,42 @@ const _build = async (options: Options) => {
 		(err) => program.error(color.red(err))
 	);
 
-	const outFile = path.join(options.cwd, OUTPUT_FILE);
+	let outDir: string;
+
+	if (config.outputDir) {
+		outDir = path.join(options.cwd, config.outputDir);
+	} else {
+		outDir = options.cwd;
+	}
+
+	const manifestOut = path.join(outDir, OUTPUT_FILE);
+
+	if (options.output && fs.existsSync(manifestOut)) {
+		// we need to remove all previously copied directories
+		if (config.outputDir) {
+			// read old manifest to determine where the unwanted files are
+			// we can't just rm -rf because other static files could be hosted out of the same directory
+			const oldCategories = JSON.parse(fs.readFileSync(manifestOut).toString()) as Category[];
+
+			// first just remove all the files
+			for (const category of oldCategories) {
+				for (const block of category.blocks) {
+					const newDirPath = path.join(outDir, block.directory);
+
+					if (fs.existsSync(newDirPath)) {
+						fs.rmSync(newDirPath, { recursive: true });
+					}
+				}
+			}
+		}
+
+		fs.rmSync(manifestOut);
+	}
 
 	for (const dir of config.dirs) {
 		const dirPath = path.join(options.cwd, dir);
 
 		loading.start(`Building ${color.cyan(dirPath)}`);
-
-		if (options.output && fs.existsSync(outFile)) fs.rmSync(outFile);
 
 		const builtCategories = buildBlocksDirectory(dirPath, { cwd: options.cwd, config });
 
@@ -190,11 +225,34 @@ const _build = async (options: Options) => {
 	}
 
 	if (options.output) {
-		loading.start(`Writing output to \`${color.cyan(outFile)}\``);
+		if (config.outputDir) {
+			loading.start(`Copying registry files to \`${color.cyan(outDir)}\``);
 
-		fs.writeFileSync(outFile, JSON.stringify(categories, null, '\t'));
+			// copy the files for each block in each category
+			for (const category of categories) {
+				for (const block of category.blocks) {
+					const originalPath = path.join(options.cwd, block.directory);
+					const newDirPath = path.join(outDir, block.directory);
 
-		loading.stop(`Wrote output to \`${color.cyan(outFile)}\``);
+					if (!fs.existsSync(newDirPath)) {
+						fs.mkdirSync(newDirPath, { recursive: true });
+					}
+
+					for (const file of block.files) {
+						fs.copyFileSync(path.join(originalPath, file), path.join(newDirPath, file));
+					}
+				}
+			}
+
+			loading.stop(`Copied registry files to \`${color.cyan(outDir)}\``);
+		}
+
+		loading.start(`Writing output to \`${color.cyan(manifestOut)}\``);
+
+		// write the manifest
+		fs.writeFileSync(manifestOut, JSON.stringify(categories, null, '\t'));
+
+		loading.stop(`Wrote output to \`${color.cyan(manifestOut)}\``);
 	}
 };
 

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { log, multiselect, outro, spinner } from '@clack/prompts';
+import { log, outro, spinner } from '@clack/prompts';
 import color from 'chalk';
 import { Command, program } from 'commander';
 import path from 'pathe';

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -14,7 +14,7 @@ import { isTestFile } from '../utils/build';
 import { type ProjectConfig, getProjectConfig, resolvePaths } from '../utils/config';
 import { installDependencies } from '../utils/dependencies';
 import { type ConcurrentTask, intro, runTasksConcurrently } from '../utils/prompts';
-import * as gitProviders from '../utils/providers';
+import * as providers from '../utils/providers';
 
 const schema = v.objectWithRest(
 	{
@@ -83,7 +83,7 @@ const _exec = async (s: string | undefined, options: Options, command: any) => {
 	if (options.repo) repoPaths = [options.repo];
 
 	// we are only getting repos for blocks that specified repos
-	if (script && gitProviders.providers.find((p) => script?.startsWith(p.name()))) {
+	if (script && providers.providers.find((p) => script?.startsWith(p.name()))) {
 		const [providerName, owner, repoName, ...rest] = script.split('/');
 
 		let repo: string;
@@ -145,8 +145,8 @@ const _exec = async (s: string | undefined, options: Options, command: any) => {
 
 	loading.start(`Fetching scripts from ${color.cyan(repoPaths.join(', '))}`);
 
-	const resolvedRepos: gitProviders.ResolvedRepo[] = (
-		await gitProviders.resolvePaths(...repoPaths)
+	const resolvedRepos: providers.ResolvedRepo[] = (
+		await providers.resolvePaths(...repoPaths)
 	).match(
 		(val) => val,
 		({ repo, message }) => {
@@ -155,7 +155,7 @@ const _exec = async (s: string | undefined, options: Options, command: any) => {
 		}
 	);
 
-	const blocksMap = (await gitProviders.fetchBlocks(...resolvedRepos)).match(
+	const blocksMap = (await providers.fetchBlocks(...resolvedRepos)).match(
 		(val) => val,
 		({ repo, message }) => {
 			loading.stop(`Failed fetching scripts from ${color.cyan(repo)}`);

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { cancel, confirm, isCancel, select, spinner } from '@clack/prompts';
 import color from 'chalk';
 import { Argument, Command, program } from 'commander';

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -14,8 +14,8 @@ import { resolveTree } from '../utils/blocks';
 import { isTestFile } from '../utils/build';
 import { type ProjectConfig, getProjectConfig, resolvePaths } from '../utils/config';
 import { installDependencies } from '../utils/dependencies';
-import * as gitProviders from '../utils/git-providers';
 import { type ConcurrentTask, intro, runTasksConcurrently } from '../utils/prompts';
+import * as gitProviders from '../utils/providers';
 
 const schema = v.objectWithRest(
 	{

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,10 +30,10 @@ import {
 } from '../utils/config';
 import { installDependencies } from '../utils/dependencies';
 import { loadFormatterConfig } from '../utils/format';
-import { providers } from '../utils/git-providers';
 import { json } from '../utils/language-support';
 import * as persisted from '../utils/persisted';
 import { type Task, intro, nextSteps, runTasks } from '../utils/prompts';
+import { providers } from '../utils/providers';
 
 const schema = v.object({
 	repos: v.optional(v.array(v.string())),

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -10,7 +10,7 @@ import { Project } from 'ts-morph';
 import * as v from 'valibot';
 import { context } from '../cli';
 import * as ascii from '../utils/ascii';
-import { getInstalled } from '../utils/blocks';
+import { fullyQualifiedName, getInstalled } from '../utils/blocks';
 import { type Block, isTestFile } from '../utils/build';
 import { getProjectConfig, resolvePaths } from '../utils/config';
 import { OUTPUT_FILE } from '../utils/context';
@@ -113,7 +113,7 @@ const _test = async (blockNames: string[], options: Options) => {
 		for (const category of categories) {
 			for (const block of category.blocks) {
 				// blocks will override each other
-				blocksMap.set(`${providerInfo.url}/${category.name}/${block.name}`, {
+				blocksMap.set(fullyQualifiedName(providerInfo.url, category.name, block.name), {
 					...block,
 					sourceRepo: providerInfo,
 				});
@@ -191,7 +191,7 @@ const _test = async (blockNames: string[], options: Options) => {
 
 			for (const category of categories) {
 				for (const block of category.blocks) {
-					blocksMap.set(`${repo}/${block.category}/${block.name}`, {
+					blocksMap.set(fullyQualifiedName(repo, block.category, block.name), {
 						...block,
 						sourceRepo: providerInfo,
 					});
@@ -221,7 +221,7 @@ const _test = async (blockNames: string[], options: Options) => {
 	for (const { block } of testingBlocksMapped) {
 		const providerInfo = block.sourceRepo;
 
-		const fullSpecifier = `${block.sourceRepo.url}/${block.category}/${block.name}`;
+		const fullSpecifier = fullyQualifiedName(block.sourceRepo.url, block.category, block.name);
 
 		if (!options.verbose) {
 			loading.start(`Setting up test file for ${color.cyan(fullSpecifier)}`);

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -168,7 +168,11 @@ const _test = async (blockNames: string[], options: Options) => {
 
 				const [parsedRepo] = providerInfo.provider.parseBlockSpecifier(providerInfo.url);
 
-				const tempBlock = blocksMap.get(new URL(blockSpecifier, parsedRepo).toString());
+				const [category, blockName] = blockSpecifier.split('/');
+
+				const tempBlock = blocksMap.get(
+					fullyQualifiedName(parsedRepo, category, blockName)
+				);
 
 				if (tempBlock === undefined) continue;
 

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -15,7 +15,7 @@ import { type Block, isTestFile } from '../utils/build';
 import { getProjectConfig, resolvePaths } from '../utils/config';
 import { OUTPUT_FILE } from '../utils/context';
 import { intro } from '../utils/prompts';
-import * as gitProviders from '../utils/providers';
+import * as providers from '../utils/providers';
 
 const schema = v.object({
 	repo: v.optional(v.string()),
@@ -45,7 +45,7 @@ const test = new Command('test')
 		outro(color.green('All done!'));
 	});
 
-type RemoteBlock = Block & { sourceRepo: gitProviders.Info };
+type RemoteBlock = Block & { sourceRepo: providers.Info };
 
 const _test = async (blockNames: string[], options: Options) => {
 	const verbose = (msg: string) => {
@@ -87,7 +87,7 @@ const _test = async (blockNames: string[], options: Options) => {
 	if (!options.verbose) loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
 
 	for (const repo of repoPaths) {
-		const providerInfo: gitProviders.Info = (await gitProviders.getProviderInfo(repo)).match(
+		const providerInfo: providers.Info = (await providers.getProviderInfo(repo)).match(
 			(info) => info,
 			(err) => program.error(color.red(err))
 		);
@@ -158,13 +158,13 @@ const _test = async (blockNames: string[], options: Options) => {
 	for (const blockSpecifier of testingBlocks) {
 		let block: RemoteBlock | undefined = undefined;
 
-		const provider = gitProviders.providers.find((p) => blockSpecifier.startsWith(p.name()));
+		const provider = providers.providers.find((p) => blockSpecifier.startsWith(p.name()));
 
 		// if the block starts with github (or another provider) we know it has been resolved
 		if (!provider) {
 			for (const repo of repoPaths) {
 				// we unwrap because we already checked this
-				const providerInfo = (await gitProviders.getProviderInfo(repo)).unwrap();
+				const providerInfo = (await providers.getProviderInfo(repo)).unwrap();
 
 				const [parsedRepo] = providerInfo.provider.parseBlockSpecifier(providerInfo.url);
 
@@ -179,7 +179,7 @@ const _test = async (blockNames: string[], options: Options) => {
 		} else {
 			const [repo] = provider.parseBlockSpecifier(blockSpecifier);
 
-			const providerInfo = (await gitProviders.getProviderInfo(repo)).match(
+			const providerInfo = (await providers.getProviderInfo(repo)).match(
 				(val) => val,
 				(err) => program.error(color.red(err))
 			);

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -14,8 +14,8 @@ import { getInstalled } from '../utils/blocks';
 import { type Block, isTestFile } from '../utils/build';
 import { getProjectConfig, resolvePaths } from '../utils/config';
 import { OUTPUT_FILE } from '../utils/context';
-import * as gitProviders from '../utils/git-providers';
 import { intro } from '../utils/prompts';
+import * as gitProviders from '../utils/providers';
 
 const schema = v.object({
 	repo: v.optional(v.string()),

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -19,7 +19,7 @@ import { loadFormatterConfig } from '../utils/format';
 import { getWatermark } from '../utils/get-watermark';
 import { returnShouldInstall } from '../utils/package';
 import { type Task, intro, nextSteps, runTasks } from '../utils/prompts';
-import * as gitProviders from '../utils/providers';
+import * as providers from '../utils/providers';
 
 const schema = v.object({
 	all: v.boolean(),
@@ -85,7 +85,7 @@ const _update = async (blockNames: string[], options: Options) => {
 
 	// ensure blocks do not provide repos
 	for (const blockSpecifier of blockNames) {
-		if (gitProviders.providers.find((p) => blockSpecifier.startsWith(p.name()))) {
+		if (providers.providers.find((p) => blockSpecifier.startsWith(p.name()))) {
 			program.error(
 				color.red(
 					`Invalid value provided for block names \`${color.bold(blockSpecifier)}\`. Block names are expected to be provided in the format of \`${color.bold('<category>/<name>')}\``
@@ -110,8 +110,8 @@ const _update = async (blockNames: string[], options: Options) => {
 
 	if (!options.verbose) loading.start(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
 
-	const resolvedRepos: gitProviders.ResolvedRepo[] = (
-		await gitProviders.resolvePaths(...repoPaths)
+	const resolvedRepos: providers.ResolvedRepo[] = (
+		await providers.resolvePaths(...repoPaths)
 	).match(
 		(val) => val,
 		({ repo, message }) => {
@@ -125,7 +125,7 @@ const _update = async (blockNames: string[], options: Options) => {
 	verbose(`Fetching blocks from ${color.cyan(repoPaths.join(', '))}`);
 
 	const blocksMap: Map<string, RemoteBlock> = (
-		await gitProviders.fetchBlocks(...resolvedRepos)
+		await providers.fetchBlocks(...resolvedRepos)
 	).match(
 		(val) => val,
 		({ repo, message }) => {

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -17,9 +17,9 @@ import { formatDiff } from '../utils/diff';
 import { transformRemoteContent } from '../utils/files';
 import { loadFormatterConfig } from '../utils/format';
 import { getWatermark } from '../utils/get-watermark';
-import * as gitProviders from '../utils/git-providers';
 import { returnShouldInstall } from '../utils/package';
 import { type Task, intro, nextSteps, runTasks } from '../utils/prompts';
+import * as gitProviders from '../utils/providers';
 
 const schema = v.object({
 	all: v.boolean(),

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -143,7 +143,13 @@ const getInstalled = (
 };
 
 const fullyQualifiedName = (url: string, category: string, name: string) => {
-	return new URL(`${category}/${name}`, url).toString();
+	let normalizedUrl = url;
+
+	if (normalizedUrl.endsWith('/')) {
+		normalizedUrl = normalizedUrl.slice(0, normalizedUrl.length - 1);
+	}
+
+	return `${normalizedUrl}/${category}/${name}`;
 };
 
 export { resolveTree, getInstalled, fullyQualifiedName };

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -6,9 +6,9 @@ import { Err, Ok, type Result } from './blocks/types/result';
 import { mapToArray } from './blocks/utils/map-to-array';
 import type { Block } from './build';
 import { type ProjectConfig, resolvePaths } from './config';
-import * as gitProviders from './providers';
+import * as providers from './providers';
 
-export type RemoteBlock = Block & { sourceRepo: gitProviders.Info };
+export type RemoteBlock = Block & { sourceRepo: providers.Info };
 
 export type InstallingBlock = {
 	name: string;
@@ -19,7 +19,7 @@ export type InstallingBlock = {
 const resolveTree = async (
 	blockSpecifiers: string[],
 	blocksMap: Map<string, RemoteBlock>,
-	repoPaths: gitProviders.ResolvedRepo[],
+	repoPaths: providers.ResolvedRepo[],
 	installed: Map<string, InstallingBlock> = new Map()
 ): Promise<Result<InstallingBlock[], string>> => {
 	const blocks = new Map<string, InstallingBlock>();
@@ -27,7 +27,7 @@ const resolveTree = async (
 	for (const blockSpecifier of blockSpecifiers) {
 		let block: RemoteBlock | undefined = undefined;
 
-		const provider = gitProviders.providers.find((p) => blockSpecifier.startsWith(p.name()));
+		const provider = providers.providers.find((p) => blockSpecifier.startsWith(p.name()));
 
 		// if the block starts with github (or another provider) we know it has been resolved
 		if (!provider) {

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -142,4 +142,8 @@ const getInstalled = (
 	return installedBlocks;
 };
 
-export { resolveTree, getInstalled };
+const fullyQualifiedName = (url: string, category: string, name: string) => {
+	return new URL(`${category}/${name}`, url).toString();
+};
+
+export { resolveTree, getInstalled, fullyQualifiedName };

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -34,8 +34,8 @@ const resolveTree = async (
 			if (repoPaths.length === 0) {
 				return Err(
 					color.red(
-						`If your config doesn't repos then you must provide the repo in the block specifier ex: \`${color.bold(
-							`github/<owner>/<name>/${blockSpecifier}`
+						`If your config doesn't contain repos then you must provide the repo in the block specifier ex: \`${color.bold(
+							`github/ieedan/std/${blockSpecifier}`
 						)}\`!`
 					)
 				);

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -52,6 +52,7 @@ export type Formatter = v.InferOutput<typeof formatterSchema>;
 const registryConfigSchema = v.object({
 	$schema: v.string(),
 	dirs: v.array(v.string()),
+	outputDir: v.optional(v.string()),
 	includeBlocks: v.optional(v.array(v.string()), []),
 	includeCategories: v.optional(v.array(v.string()), []),
 	excludeBlocks: v.optional(v.array(v.string()), []),

--- a/packages/cli/src/utils/providers.ts
+++ b/packages/cli/src/utils/providers.ts
@@ -618,10 +618,12 @@ const http: Provider = {
 	defaultBranch: () => '',
 	refSpecifierExample: () => '',
 	parseBlockSpecifier: (blockSpecifier) => {
-		const segments = blockSpecifier.split('/');
+		const url = new URL(blockSpecifier);
+
+		const segments = url.pathname.split('/');
 
 		return [
-			segments.slice(0, segments.length - 2).join('/'),
+			new URL(segments.slice(0, segments.length - 2).join('/'), url.origin).toString(),
 			segments.slice(segments.length - 2).join('/'),
 		];
 	},

--- a/packages/cli/src/utils/providers.ts
+++ b/packages/cli/src/utils/providers.ts
@@ -702,7 +702,7 @@ const getProviderInfo = async (repo: string): Promise<Result<Info, string>> => {
 	}
 
 	return Err(
-		`Only ${providers.map((p, i) => `${i === providers.length - 1 ? 'and' : ''}${color.cyan(p.name())}`).join(', ')} repositories are supported at this time!`
+		`Only ${providers.map((p, i) => `${i === providers.length - 1 ? 'and ' : ''}${color.bold(p.name())}`).join(', ')} registries are supported at this time!`
 	);
 };
 

--- a/packages/cli/tests/add.test.ts
+++ b/packages/cli/tests/add.test.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import { execa } from 'execa';
+import path from 'pathe';
+import { afterAll, beforeAll, describe, it } from 'vitest';
+import { cli } from '../src/cli';
+import type { ProjectConfig } from '../src/utils/config';
+import { assertFilesExist } from './utils';
+
+describe('add', () => {
+	const testDir = path.join(__dirname, '../temp-test/add');
+
+	const addBlock = async (registry: string, block: `${string}/${string}`) => {
+		const config: ProjectConfig = {
+			$schema: '',
+			includeTests: false,
+			paths: {
+				'*': './src',
+			},
+			repos: [registry],
+			watermark: true,
+		};
+
+		fs.writeFileSync('jsrepo.json', JSON.stringify(config));
+
+		await cli.parseAsync(['node', 'jsrepo', 'add', block, '-y', '--verbose', '--cwd', testDir]);
+	};
+
+	beforeAll(async () => {
+		if (fs.existsSync(testDir)) {
+			fs.rmdirSync(testDir, { recursive: true });
+		}
+
+		fs.mkdirSync(testDir, { recursive: true });
+		// cd into testDir
+		process.chdir(testDir);
+
+		// create package.json
+		await execa`pnpm init`;
+	});
+
+	afterAll(() => {
+		process.chdir(__dirname); // unlock directory
+
+		fs.rmdirSync(testDir, { recursive: true });
+	});
+
+	it('adds from github', async () => {
+		await addBlock('github/ieedan/std/tree/v2.2.0', 'utils/math');
+
+		const blockBaseDir = './src/utils/math';
+
+		const expectedFiles = [
+			'circle.ts',
+			'conversions.ts',
+			'fractions.ts',
+			'gcf.ts',
+			'index.ts',
+			'triangles.ts',
+			'types.ts',
+		];
+
+		assertFilesExist(blockBaseDir, ...expectedFiles);
+	});
+
+	it('adds from gitlab', async () => {
+		await addBlock('gitlab/ieedan/std', 'utils/math');
+
+		const blockBaseDir = './src/utils/math';
+
+		const expectedFiles = [
+			'circle.ts',
+			'conversions.ts',
+			'fractions.ts',
+			'gcf.ts',
+			'index.ts',
+			'triangles.ts',
+			'types.ts',
+		];
+
+		assertFilesExist(blockBaseDir, ...expectedFiles);
+	});
+
+	it('adds from azure', async () => {
+		await addBlock('azure/ieedan/std/std', 'utils/math');
+
+		const blockBaseDir = './src/utils/math';
+
+		const expectedFiles = [
+			'circle.ts',
+			'conversions.ts',
+			'fractions.ts',
+			'gcf.ts',
+			'index.ts',
+			'triangles.ts',
+			'types.ts',
+		];
+
+		assertFilesExist(blockBaseDir, ...expectedFiles);
+	});
+
+	it('adds from http', async () => {
+		await addBlock('https://jsrepo-http.vercel.app/', 'utils/math');
+
+		const blockBaseDir = './src/utils/math';
+
+		const expectedFiles = [
+			'circle.ts',
+			'conversions.ts',
+			'fractions.ts',
+			'gcf.ts',
+			'index.ts',
+			'triangles.ts',
+			'types.ts',
+		];
+
+		assertFilesExist(blockBaseDir, ...expectedFiles);
+	});
+});

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -2,8 +2,8 @@ import fs from 'node:fs';
 import path from 'pathe';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { cli } from '../src/cli';
-import type { RegistryConfig } from '../src/utils/config';
 import type { Category } from '../src/utils/build';
+import type { RegistryConfig } from '../src/utils/config';
 
 describe('add', () => {
 	const testDir = path.join(__dirname, '../temp-test/build');

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { cli } from '../src/cli';
 import type { Category } from '../src/utils/build';
 import type { RegistryConfig } from '../src/utils/config';
+import { assertFilesExist } from './utils';
 
 describe('add', () => {
 	const testDir = path.join(__dirname, '../temp-test/build');
@@ -111,5 +112,90 @@ export const log = (msg: string) => console.info(color.cyan(msg));`
 				name: 'utils',
 			},
 		] satisfies Category[]);
+	});
+
+	it('builds and copies files to correct location', async () => {
+		// create package.json
+		const pkg = {
+			name: 'registry',
+			dependencies: {
+				chalk: '^5.3.0',
+			},
+		};
+
+		fs.writeFileSync('package.json', JSON.stringify(pkg));
+
+		fs.mkdirSync('./src/utils', { recursive: true });
+
+		fs.writeFileSync(
+			'./src/utils/add.ts',
+			`import { log } from "./log";
+
+export const add = (a: number, b: number) => a + b;
+
+export const logAnswer = (a: number, b: number) => log(\`Answer is: \${add(a, b)}\`);`
+		);
+		fs.writeFileSync(
+			'./src/utils/log.ts',
+			`import color from "chalk";
+            
+export const log = (msg: string) => console.info(color.cyan(msg));`
+		);
+
+		// build
+
+		await cli.parseAsync([
+			'node',
+			'jsrepo',
+			'build',
+			'--cwd',
+			testDir,
+			'--dirs',
+			'./src',
+			'--output-dir',
+			'./registry',
+		]);
+
+		const manifest = JSON.parse(
+			fs.readFileSync('./registry/jsrepo-manifest.json').toString()
+		) as Category[];
+
+		expect(manifest).toStrictEqual([
+			{
+				blocks: [
+					{
+						_imports_: {
+							'./log': '{{utils/log}}',
+						},
+						category: 'utils',
+						dependencies: [],
+						devDependencies: [],
+						directory: 'src/utils',
+						files: ['add.ts'],
+						list: true,
+						localDependencies: ['utils/log'],
+						name: 'add',
+						subdirectory: false,
+						tests: false,
+					},
+					{
+						_imports_: {},
+						category: 'utils',
+						dependencies: ['chalk@^5.3.0'],
+						devDependencies: [],
+						directory: 'src/utils',
+						files: ['log.ts'],
+						list: true,
+						localDependencies: [],
+						name: 'log',
+						subdirectory: false,
+						tests: false,
+					},
+				],
+				name: 'utils',
+			},
+		] satisfies Category[]);
+
+		assertFilesExist('./registry/src/utils', 'add.ts', 'log.ts');
 	});
 });

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import path from 'pathe';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { cli } from '../src/cli';
+import type { RegistryConfig } from '../src/utils/config';
+import type { Category } from '../src/utils/build';
+
+describe('add', () => {
+	const testDir = path.join(__dirname, '../temp-test/build');
+
+	beforeAll(async () => {
+		if (fs.existsSync(testDir)) {
+			fs.rmdirSync(testDir, { recursive: true });
+		}
+
+		fs.mkdirSync(testDir, { recursive: true });
+		// cd into testDir
+		process.chdir(testDir);
+	});
+
+	afterAll(() => {
+		process.chdir(__dirname); // unlock directory
+
+		fs.rmdirSync(testDir, { recursive: true });
+	});
+
+	it('builds local and remote dependencies', async () => {
+		// create package.json
+		const pkg = {
+			name: 'registry',
+			dependencies: {
+				chalk: '^5.3.0',
+			},
+		};
+
+		fs.writeFileSync('package.json', JSON.stringify(pkg));
+
+		const config: RegistryConfig = {
+			$schema: '',
+			dirs: ['./src'],
+			includeBlocks: [],
+			includeCategories: [],
+			excludeBlocks: [],
+			excludeCategories: [],
+			doNotListBlocks: [],
+			doNotListCategories: [],
+			listBlocks: [],
+			listCategories: [],
+			excludeDeps: [],
+		};
+
+		fs.writeFileSync('jsrepo-build-config.json', JSON.stringify(config));
+
+		fs.mkdirSync('./src/utils', { recursive: true });
+
+		fs.writeFileSync(
+			'./src/utils/add.ts',
+			`import { log } from "./log";
+
+export const add = (a: number, b: number) => a + b;
+
+export const logAnswer = (a: number, b: number) => log(\`Answer is: \${add(a, b)}\`);`
+		);
+		fs.writeFileSync(
+			'./src/utils/log.ts',
+			`import color from "chalk";
+            
+export const log = (msg: string) => console.info(color.cyan(msg));`
+		);
+
+		// build
+
+		await cli.parseAsync(['node', 'jsrepo', 'build', '--cwd', testDir]);
+
+		const manifest = JSON.parse(
+			fs.readFileSync('jsrepo-manifest.json').toString()
+		) as Category[];
+
+		expect(manifest).toStrictEqual([
+			{
+				blocks: [
+					{
+						_imports_: {
+							'./log': '{{utils/log}}',
+						},
+						category: 'utils',
+						dependencies: [],
+						devDependencies: [],
+						directory: 'src/utils',
+						files: ['add.ts'],
+						list: true,
+						localDependencies: ['utils/log'],
+						name: 'add',
+						subdirectory: false,
+						tests: false,
+					},
+					{
+						_imports_: {},
+						category: 'utils',
+						dependencies: ['chalk@^5.3.0'],
+						devDependencies: [],
+						directory: 'src/utils',
+						files: ['log.ts'],
+						list: true,
+						localDependencies: [],
+						name: 'log',
+						subdirectory: false,
+						tests: false,
+					},
+				],
+				name: 'utils',
+			},
+		] satisfies Category[]);
+	});
+});

--- a/packages/cli/tests/git-providers.test.ts
+++ b/packages/cli/tests/git-providers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import * as gitProviders from '../src/utils/git-providers';
+import * as gitProviders from '../src/utils/providers';
 
 describe('github', () => {
 	it('Fetches the manifest from a public repo', async () => {

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import * as gitProviders from '../src/utils/providers';
+import * as providers from '../src/utils/providers';
 
 describe('github', () => {
 	it('Fetches the manifest from a public repo', async () => {
 		const repoURL = 'github/ieedan/std';
 
-		const info = await gitProviders.github.info(repoURL);
+		const info = await providers.github.info(repoURL);
 
-		const content = await gitProviders.github.fetchManifest(info);
+		const content = await providers.github.fetchManifest(info);
 
 		expect(content.isErr()).toBe(false);
 	});
@@ -15,9 +15,9 @@ describe('github', () => {
 	it('Fetches the manifest from a public repo with a tag', async () => {
 		const repoURL = 'https://github.com/ieedan/std/tree/v1.6.0';
 
-		const info = await gitProviders.github.info(repoURL);
+		const info = await providers.github.info(repoURL);
 
-		const content = await gitProviders.github.fetchRaw(info, 'jsrepo-manifest.json');
+		const content = await providers.github.fetchRaw(info, 'jsrepo-manifest.json');
 
 		expect(content.unwrap()).toBe(`[
 	{
@@ -206,9 +206,9 @@ describe('gitlab', () => {
 	it('Fetches the manifest from a public repo', async () => {
 		const repoURL = 'gitlab/ieedan/std';
 
-		const info = await gitProviders.gitlab.info(repoURL);
+		const info = await providers.gitlab.info(repoURL);
 
-		const content = await gitProviders.gitlab.fetchManifest(info);
+		const content = await providers.gitlab.fetchManifest(info);
 
 		expect(content.isErr()).toBe(false);
 	});
@@ -216,9 +216,9 @@ describe('gitlab', () => {
 	it('Fetches the manifest from a public repo with a tag', async () => {
 		const repoURL = 'https://gitlab.com/ieedan/std/-/tree/v1.6.0';
 
-		const info = await gitProviders.gitlab.info(repoURL);
+		const info = await providers.gitlab.info(repoURL);
 
-		const content = await gitProviders.gitlab.fetchRaw(info, 'jsrepo-manifest.json');
+		const content = await providers.gitlab.fetchRaw(info, 'jsrepo-manifest.json');
 
 		expect(content.unwrap()).toBe(`[
 	{
@@ -407,9 +407,9 @@ describe('bitbucket', () => {
 	it('Fetches the manifest from a public repo', async () => {
 		const repoURL = 'bitbucket/ieedan/std';
 
-		const info = await gitProviders.bitbucket.info(repoURL);
+		const info = await providers.bitbucket.info(repoURL);
 
-		const content = await gitProviders.bitbucket.fetchManifest(info);
+		const content = await providers.bitbucket.fetchManifest(info);
 
 		expect(content.isErr()).toBe(false);
 	});
@@ -417,9 +417,9 @@ describe('bitbucket', () => {
 	it('Fetches the manifest from a public repo with a tag', async () => {
 		const repoURL = 'https://bitbucket.org/ieedan/std/src/v1.6.0';
 
-		const info = await gitProviders.bitbucket.info(repoURL);
+		const info = await providers.bitbucket.info(repoURL);
 
-		const content = await gitProviders.bitbucket.fetchRaw(info, 'jsrepo-manifest.json');
+		const content = await providers.bitbucket.fetchRaw(info, 'jsrepo-manifest.json');
 
 		expect(content.unwrap()).toBe(`[
 	{
@@ -608,9 +608,9 @@ describe('azure', () => {
 	it('Fetches the manifest from a public repo', async () => {
 		const repoURL = 'azure/ieedan/std/std';
 
-		const info = await gitProviders.azure.info(repoURL);
+		const info = await providers.azure.info(repoURL);
 
-		const content = await gitProviders.azure.fetchManifest(info);
+		const content = await providers.azure.fetchManifest(info);
 
 		expect(content.isErr()).toBe(false);
 	});
@@ -618,9 +618,9 @@ describe('azure', () => {
 	it('Fetches the manifest from a public repo with a tag', async () => {
 		const repoURL = 'azure/ieedan/std/std/tags/v1.6.0';
 
-		const info = await gitProviders.azure.info(repoURL);
+		const info = await providers.azure.info(repoURL);
 
-		const content = await gitProviders.azure.fetchRaw(info, 'jsrepo-manifest.json');
+		const content = await providers.azure.fetchRaw(info, 'jsrepo-manifest.json');
 
 		expect(content.unwrap()).toBe(`[
 	{
@@ -809,9 +809,9 @@ describe('http', () => {
 	it('Fetches the manifest', async () => {
 		const repoURL = 'https://jsrepo-http.vercel.app';
 
-		const info = await gitProviders.http.info(repoURL);
+		const info = await providers.http.info(repoURL);
 
-		const content = await gitProviders.http.fetchRaw(info, 'jsrepo-manifest.json');
+		const content = await providers.http.fetchRaw(info, 'jsrepo-manifest.json');
 
 		expect(content.unwrap()).toBe(`[
 	{

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -804,3 +804,308 @@ describe('azure', () => {
 `);
 	});
 });
+
+describe('http', () => {
+	it('Fetches the manifest', async () => {
+		const repoURL = 'https://jsrepo-http.vercel.app';
+
+		const info = await gitProviders.http.info(repoURL);
+
+		const content = await gitProviders.http.fetchRaw(info, 'jsrepo-manifest.json');
+
+		expect(content.unwrap()).toBe(`[
+	{
+		"name": "types",
+		"blocks": [
+			{
+				"name": "result",
+				"directory": "src/types",
+				"category": "types",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"result.ts",
+					"result.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	},
+	{
+		"name": "utils",
+		"blocks": [
+			{
+				"name": "array-sum",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"array-sum.ts",
+					"array-sum.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "array-to-map",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"array-to-map.ts",
+					"array-to-map.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "dispatcher",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"dispatcher.ts",
+					"dispatcher.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "ipv4-address",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"ipv4-address.ts",
+					"ipv4-address.test.ts"
+				],
+				"localDependencies": [
+					"types/result",
+					"utils/is-number"
+				],
+				"_imports_": {
+					"../types/result": "{{types/result}}",
+					"./is-number": "{{utils/is-number}}"
+				},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "is-number",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"is-number.ts",
+					"is-number.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "lines",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"lines.ts",
+					"lines.test.ts"
+				],
+				"localDependencies": [
+					"utils/pad"
+				],
+				"_imports_": {
+					"./pad": "{{utils/pad}}"
+				},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "map-to-array",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"map-to-array.ts",
+					"map-to-array.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "math",
+				"directory": "src/utils/math",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": true,
+				"list": true,
+				"files": [
+					"circle.test.ts",
+					"circle.ts",
+					"conversions.test.ts",
+					"conversions.ts",
+					"fractions.test.ts",
+					"fractions.ts",
+					"gcf.test.ts",
+					"gcf.ts",
+					"index.ts",
+					"triangles.test.ts",
+					"triangles.ts",
+					"types.ts"
+				],
+				"localDependencies": [],
+				"dependencies": [],
+				"devDependencies": [],
+				"_imports_": {}
+			},
+			{
+				"name": "pad",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"pad.ts",
+					"pad.test.ts"
+				],
+				"localDependencies": [
+					"utils/strip-ansi"
+				],
+				"_imports_": {
+					"./strip-ansi": "{{utils/strip-ansi}}"
+				},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "perishable-list",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"perishable-list.ts",
+					"perishable-list.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "rand",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"rand.ts",
+					"rand.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "sleep",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"sleep.ts",
+					"sleep.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "stopwatch",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"stopwatch.ts",
+					"stopwatch.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			},
+			{
+				"name": "strip-ansi",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"strip-ansi.ts",
+					"strip-ansi.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [
+					"ansi-regex@^6.1.0"
+				],
+				"devDependencies": []
+			},
+			{
+				"name": "truncate",
+				"directory": "src/utils",
+				"category": "utils",
+				"tests": true,
+				"subdirectory": false,
+				"list": true,
+				"files": [
+					"truncate.ts",
+					"truncate.test.ts"
+				],
+				"localDependencies": [],
+				"_imports_": {},
+				"dependencies": [],
+				"devDependencies": []
+			}
+		]
+	}
+]`);
+	});
+});

--- a/packages/cli/tests/utils.ts
+++ b/packages/cli/tests/utils.ts
@@ -1,5 +1,5 @@
-import { expect } from 'vitest';
 import fs from 'node:fs';
+import { expect } from 'vitest';
 
 export const assertFilesExist = (dir: string, ...files: string[]) => {
 	const fileSet = new Set(files);

--- a/packages/cli/tests/utils.ts
+++ b/packages/cli/tests/utils.ts
@@ -1,0 +1,14 @@
+import { expect } from 'vitest';
+import fs from 'node:fs';
+
+export const assertFilesExist = (dir: string, ...files: string[]) => {
+	const fileSet = new Set(files);
+
+	const filesInDir = fs.readdirSync(dir);
+
+	for (const file of filesInDir) {
+		fileSet.delete(file);
+	}
+
+	expect(Array.from(fileSet)).toStrictEqual([]);
+};

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: 'node',
+		exclude: ['**/temp-test/**', 'dist/**', 'coverage/**'],
+	},
+	server: {
+		watch: {
+			ignored: ['**/temp-test/**', 'dist/**', 'coverage/**'],
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,25 @@ importers:
         specifier: ^0.0.39
         version: 0.0.39
 
+  examples/registry:
+    dependencies:
+      chalk:
+        specifier: ^5.3.0
+        version: 5.4.1
+      radix-vue:
+        specifier: ^1.9.12
+        version: 1.9.12(vue@3.5.13(typescript@5.7.3))
+    devDependencies:
+      jsrepo:
+        specifier: ^1.2.4
+        version: 1.25.0(typescript@5.7.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.3
+      vitest:
+        specifier: ^2.1.5
+        version: 2.1.8(@types/node@22.10.7)
+
   packages/cli:
     dependencies:
       '@biomejs/js-api':
@@ -852,6 +871,12 @@ packages:
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
+  '@floating-ui/utils@0.2.9':
+    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@floating-ui/vue@1.1.6':
+    resolution: {integrity: sha512-XFlUzGHGv12zbgHNk5FN2mUB7ROul3oG2ENdTpWdE+qMFxyNxWSRmsoyhiEnpmabNm6WnUvR1OvJfUfN4ojC1A==}
+
   '@fontsource-variable/jetbrains-mono@5.1.2':
     resolution: {integrity: sha512-syGEJ/N4FFisAXegxtbe1etYpo2T630dqCbYufPf7Dli/hMKSoSUIm3wK4q5RsGFRxWno1WecfnsgZA1jRK0EQ==}
 
@@ -880,6 +905,9 @@ packages:
 
   '@internationalized/date@3.6.0':
     resolution: {integrity: sha512-+z6ti+CcJnRlLHok/emGEsWQhe7kfSmEW+/6qCzvKY67YPh7YOBfvc7+/+NXq+zJlbArg30tYpqLjNgcAYv2YQ==}
+
+  '@internationalized/number@3.6.0':
+    resolution: {integrity: sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1363,6 +1391,14 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@tanstack/virtual-core@3.11.2':
+    resolution: {integrity: sha512-vTtpNt7mKCiZ1pwU9hfKPhpdVO2sVzFQsxoVBGtOSHxlrRRzYr8iQ2TlwbAcRYCcEiZ9ECAM8kBzH0v2+VzfKw==}
+
+  '@tanstack/vue-virtual@3.11.2':
+    resolution: {integrity: sha512-y0b1p1FTlzxcSt/ZdGWY1AZ52ddwSU69pvFRYAELUSdLLxV8QOPe9dyT/KATO43UCb3DAwiyzi96h2IoYstBOQ==}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.0.0
+
   '@ts-morph/common@0.26.0':
     resolution: {integrity: sha512-/RmKAtctStXqM5nECMQ46duT74Hoig/DBzhWXGHcodlDNrgRbsbwwHqSKFNbca6z9Xt/CUWMeXOsC9QEN1+rqw==}
 
@@ -1404,6 +1440,9 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@types/web-bluetooth@0.0.20':
+    resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
 
   '@typescript-eslint/eslint-plugin@8.20.0':
     resolution: {integrity: sha512-naduuphVw5StFfqp4Gq4WhIBE2gN1GEmMUExpJYknZJdRnc+2gDzB8Z3+5+/Kv33hPQRDGzQO/0opHE72lZZ6A==}
@@ -1518,6 +1557,15 @@ packages:
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
 
+  '@vueuse/core@10.11.1':
+    resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
+
+  '@vueuse/metadata@10.11.1':
+    resolution: {integrity: sha512-IGa5FXd003Ug1qAZmyE8wF3sJ81xGLSqTqtQ6jaVfkeZ4i5kS2mwQF61yhVqojRnenVew5PldLyRgvdl4YYuSw==}
+
+  '@vueuse/shared@10.11.1':
+    resolution: {integrity: sha512-LHpC8711VFZlDaYUXEBbFBCQ7GS3dVU9mjOhhMhXP6txTV4EhYQg/KGnQuvt/sPAtoUKq7VVUnL6mVtFoL42sA==}
+
   abbrev@2.0.0:
     resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -1595,6 +1643,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.4:
+    resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
+    engines: {node: '>=10'}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -1827,6 +1879,9 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
@@ -2328,6 +2383,10 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  jsrepo@1.25.0:
+    resolution: {integrity: sha512-0J2tu6fZq85Cy89JEBfwCLp3KSzV+8qYkSyChvQDCuU54FJaJEz5E6YwVy1g0Z0IEzR2MlWyprV9FYDulAaV/A==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -2480,6 +2539,11 @@ packages:
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.0.9:
+    resolution: {integrity: sha512-Aooyr6MXU6HpvvWXKoVoXwKMs/KyVakWwg7xQfv5/S/RIgJMy0Ifa45H9qqYy7pTCszrHzP21Uk4PZq2HpEM8Q==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   natural-compare@1.4.0:
@@ -2806,6 +2870,11 @@ packages:
   quick-lru@7.0.0:
     resolution: {integrity: sha512-MX8gB7cVYTrYcFfAnfLlhRd0+Toyl8yX8uBx1MrX7K0jegiz9TumwOK27ldXrgDlHRdVi+MqU9Ssw6dr4BNreg==}
     engines: {node: '>=18'}
+
+  radix-vue@1.9.12:
+    resolution: {integrity: sha512-zkr66Jqxbej4+oR6O/pZRzyM/VZi66ndbyIBZQjJKAXa1lIoYReZJse6W1EEDZKXknD7rXhpS+jM9Sr23lIqfg==}
+    peerDependencies:
+      vue: '>= 3.2.0'
 
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -3390,6 +3459,17 @@ packages:
       jsdom:
         optional: true
 
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   vue@3.5.13:
     resolution: {integrity: sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==}
     peerDependencies:
@@ -3965,6 +4045,17 @@ snapshots:
 
   '@floating-ui/utils@0.2.8': {}
 
+  '@floating-ui/utils@0.2.9': {}
+
+  '@floating-ui/vue@1.1.6(vue@3.5.13(typescript@5.7.3))':
+    dependencies:
+      '@floating-ui/dom': 1.6.12
+      '@floating-ui/utils': 0.2.9
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.7.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   '@fontsource-variable/jetbrains-mono@5.1.2': {}
 
   '@fontsource/inter@5.1.1': {}
@@ -3983,6 +4074,10 @@ snapshots:
   '@humanwhocodes/retry@0.4.1': {}
 
   '@internationalized/date@3.6.0':
+    dependencies:
+      '@swc/helpers': 0.5.15
+
+  '@internationalized/number@3.6.0':
     dependencies:
       '@swc/helpers': 0.5.15
 
@@ -4508,6 +4603,13 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.17
 
+  '@tanstack/virtual-core@3.11.2': {}
+
+  '@tanstack/vue-virtual@3.11.2(vue@3.5.13(typescript@5.7.3))':
+    dependencies:
+      '@tanstack/virtual-core': 3.11.2
+      vue: 3.5.13(typescript@5.7.3)
+
   '@ts-morph/common@0.26.0':
     dependencies:
       fast-glob: 3.3.3
@@ -4548,6 +4650,8 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@types/web-bluetooth@0.0.20': {}
 
   '@typescript-eslint/eslint-plugin@8.20.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.7.3))(eslint@9.18.0(jiti@1.21.6))(typescript@5.7.3)':
     dependencies:
@@ -4741,6 +4845,25 @@ snapshots:
 
   '@vue/shared@3.5.13': {}
 
+  '@vueuse/core@10.11.1(vue@3.5.13(typescript@5.7.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.20
+      '@vueuse/metadata': 10.11.1
+      '@vueuse/shared': 10.11.1(vue@3.5.13(typescript@5.7.3))
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.7.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
+  '@vueuse/metadata@10.11.1': {}
+
+  '@vueuse/shared@10.11.1(vue@3.5.13(typescript@5.7.3))':
+    dependencies:
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.7.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
+
   abbrev@2.0.0: {}
 
   acorn-import-attributes@1.9.5(acorn@8.14.0):
@@ -4803,6 +4926,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.4:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.3.2: {}
 
@@ -5004,6 +5131,8 @@ snapshots:
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
+
+  defu@6.1.4: {}
 
   deprecation@2.3.1: {}
 
@@ -5579,6 +5708,37 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsrepo@1.25.0(typescript@5.7.3):
+    dependencies:
+      '@biomejs/js-api': 0.7.1(@biomejs/wasm-nodejs@1.9.4)
+      '@biomejs/wasm-nodejs': 1.9.4
+      '@clack/prompts': 0.9.1
+      ansi-regex: 6.1.0
+      chalk: 5.4.1
+      commander: 13.0.0
+      conf: 13.1.0
+      diff: 7.0.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      execa: 9.5.2
+      get-tsconfig: 4.8.1
+      node-fetch: 3.3.2
+      octokit: 4.1.0
+      package-manager-detector: 0.2.8
+      parse5: 7.2.1
+      pathe: 2.0.1
+      prettier: 3.4.2
+      semver: 7.6.3
+      svelte: 5.18.0
+      ts-morph: 25.0.0
+      valibot: 1.0.0-beta.11(typescript@5.7.3)
+      validate-npm-package-name: 6.0.0
+      vue: 3.5.13(typescript@5.7.3)
+    transitivePeerDependencies:
+      - '@biomejs/wasm-bundler'
+      - '@biomejs/wasm-web'
+      - typescript
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -5717,6 +5877,8 @@ snapshots:
   nanoid@3.3.7: {}
 
   nanoid@3.3.8: {}
+
+  nanoid@5.0.9: {}
 
   natural-compare@1.4.0: {}
 
@@ -5988,6 +6150,23 @@ snapshots:
   queue-microtask@1.2.3: {}
 
   quick-lru@7.0.0: {}
+
+  radix-vue@1.9.12(vue@3.5.13(typescript@5.7.3)):
+    dependencies:
+      '@floating-ui/dom': 1.6.12
+      '@floating-ui/vue': 1.1.6(vue@3.5.13(typescript@5.7.3))
+      '@internationalized/date': 3.6.0
+      '@internationalized/number': 3.6.0
+      '@tanstack/vue-virtual': 3.11.2(vue@3.5.13(typescript@5.7.3))
+      '@vueuse/core': 10.11.1(vue@3.5.13(typescript@5.7.3))
+      '@vueuse/shared': 10.11.1(vue@3.5.13(typescript@5.7.3))
+      aria-hidden: 1.2.4
+      defu: 6.1.4
+      fast-deep-equal: 3.1.3
+      nanoid: 5.0.9
+      vue: 3.5.13(typescript@5.7.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
 
   read-cache@1.0.0:
     dependencies:
@@ -6596,6 +6775,10 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  vue-demi@0.14.10(vue@3.5.13(typescript@5.7.3)):
+    dependencies:
+      vue: 3.5.13(typescript@5.7.3)
 
   vue@3.5.13(typescript@5.7.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^7.6.3
         version: 7.6.3
       svelte:
-        specifier: ^5.17.5
-        version: 5.17.5
+        specifier: ^5.18.0
+        version: 5.18.0
       ts-morph:
         specifier: ^25.0.0
         version: 25.0.0
@@ -97,8 +97,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       '@types/node':
-        specifier: ^22.10.5
-        version: 22.10.5
+        specifier: ^22.10.7
+        version: 22.10.7
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
@@ -107,19 +107,19 @@ importers:
         version: 4.0.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(jiti@1.21.6)(postcss@8.4.49)(typescript@5.7.3)(yaml@2.6.1)
+        version: 8.3.5(jiti@1.21.6)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.6.1)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@22.10.5)
+        version: 2.1.8(@types/node@22.10.7)
 
   sites/docs:
     dependencies:
       '@sveltejs/adapter-vercel':
         specifier: ^5.5.2
-        version: 5.5.2(@sveltejs/kit@2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)))(rollup@4.27.4)
+        version: 5.5.2(@sveltejs/kit@2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)))(rollup@4.30.1)
     devDependencies:
       '@fontsource-variable/jetbrains-mono':
         specifier: ^5.1.2
@@ -129,10 +129,10 @@ importers:
         version: 5.1.1
       '@sveltejs/kit':
         specifier: ^2.15.2
-        version: 2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))
+        version: 2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.3
-        version: 5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))
+        version: 5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@3.4.17)
@@ -213,7 +213,7 @@ importers:
         version: 1.0.0-next.3(svelte@5.17.5)
       vite:
         specifier: ^6.0.7
-        version: 6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)
+        version: 6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)
 
 packages:
 
@@ -233,8 +233,8 @@ packages:
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.26.2':
-    resolution: {integrity: sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==}
+  '@babel/parser@7.26.5':
+    resolution: {integrity: sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -242,8 +242,8 @@ packages:
     resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.26.0':
-    resolution: {integrity: sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==}
+  '@babel/types@7.26.5':
+    resolution: {integrity: sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==}
     engines: {node: '>=6.9.0'}
 
   '@biomejs/biome@1.9.4':
@@ -889,8 +889,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@jridgewell/gen-mapping@0.3.5':
-    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
+  '@jridgewell/gen-mapping@0.3.8':
+    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/resolve-uri@3.1.2':
@@ -982,8 +982,8 @@ packages:
     resolution: {integrity: sha512-z+j7DixNnfpdToYsOutStDgeRzJSMnbj8T1C/oQjB6Aa+kRfNjs/Fn7W6c8bmlt6mfy3FkgeKBRnDjxQow5dow==}
     engines: {node: '>= 18'}
 
-  '@octokit/endpoint@10.1.1':
-    resolution: {integrity: sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==}
+  '@octokit/endpoint@10.1.2':
+    resolution: {integrity: sha512-XybpFv9Ms4hX5OCHMZqyODYqGTZ3H6K6Vva+M9LR7ib/xr1y1ZnlChYv9H680y77Vd/i/k+thXApeRASBQkzhA==}
     engines: {node: '>= 18'}
 
   '@octokit/endpoint@9.0.5':
@@ -1118,8 +1118,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.30.1':
+    resolution: {integrity: sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.27.4':
     resolution: {integrity: sha512-wzKRQXISyi9UdCVRqEd0H4cMpzvHYt1f/C3CoIjES6cG++RHKhrBj2+29nPF0IB5kpy9MS71vs07fvrNGAl/iA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.30.1':
+    resolution: {integrity: sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==}
     cpu: [arm64]
     os: [android]
 
@@ -1128,8 +1138,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.30.1':
+    resolution: {integrity: sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.27.4':
     resolution: {integrity: sha512-o9bH2dbdgBDJaXWJCDTNDYa171ACUdzpxSZt+u/AAeQ20Nk5x+IhA+zsGmrQtpkLiumRJEYef68gcpn2ooXhSQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.30.1':
+    resolution: {integrity: sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==}
     cpu: [x64]
     os: [darwin]
 
@@ -1138,8 +1158,18 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.30.1':
+    resolution: {integrity: sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.27.4':
     resolution: {integrity: sha512-wYcC5ycW2zvqtDYrE7deary2P2UFmSh85PUpAx+dwTCO9uw3sgzD6Gv9n5X4vLaQKsrfTSZZ7Z7uynQozPVvWA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.30.1':
+    resolution: {integrity: sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==}
     cpu: [x64]
     os: [freebsd]
 
@@ -1148,8 +1178,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.30.1':
+    resolution: {integrity: sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.27.4':
     resolution: {integrity: sha512-Vgdo4fpuphS9V24WOV+KwkCVJ72u7idTgQaBoLRD0UxBAWTF9GWurJO9YD9yh00BzbkhpeXtm6na+MvJU7Z73A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.30.1':
+    resolution: {integrity: sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==}
     cpu: [arm]
     os: [linux]
 
@@ -1158,13 +1198,33 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.30.1':
+    resolution: {integrity: sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.27.4':
     resolution: {integrity: sha512-caluiUXvUuVyCHr5DxL8ohaaFFzPGmgmMvwmqAITMpV/Q+tPoaHZ/PWa3t8B2WyoRcIIuu1hkaW5KkeTDNSnMA==}
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-musl@4.30.1':
+    resolution: {integrity: sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.30.1':
+    resolution: {integrity: sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==}
+    cpu: [loong64]
+    os: [linux]
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.27.4':
     resolution: {integrity: sha512-FScrpHrO60hARyHh7s1zHE97u0KlT/RECzCKAdmI+LEoC1eDh/RDji9JgFqyO+wPDb86Oa/sXkily1+oi4FzJQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.30.1':
+    resolution: {integrity: sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==}
     cpu: [ppc64]
     os: [linux]
 
@@ -1173,8 +1233,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-gnu@4.30.1':
+    resolution: {integrity: sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-s390x-gnu@4.27.4':
     resolution: {integrity: sha512-PFz+y2kb6tbh7m3A7nA9++eInGcDVZUACulf/KzDtovvdTizHpZaJty7Gp0lFwSQcrnebHOqxF1MaKZd7psVRg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.30.1':
+    resolution: {integrity: sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==}
     cpu: [s390x]
     os: [linux]
 
@@ -1183,8 +1253,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-gnu@4.30.1':
+    resolution: {integrity: sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-musl@4.27.4':
     resolution: {integrity: sha512-5AeeAF1PB9TUzD+3cROzFTnAJAcVUGLuR8ng0E0WXGkYhp6RD6L+6szYVX+64Rs0r72019KHZS1ka1q+zU/wUw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.30.1':
+    resolution: {integrity: sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==}
     cpu: [x64]
     os: [linux]
 
@@ -1193,13 +1273,28 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rollup/rollup-win32-arm64-msvc@4.30.1':
+    resolution: {integrity: sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.27.4':
     resolution: {integrity: sha512-KtwEJOaHAVJlxV92rNYiG9JQwQAdhBlrjNRp7P9L8Cb4Rer3in+0A+IPhJC9y68WAi9H0sX4AiG2NTsVlmqJeQ==}
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.30.1':
+    resolution: {integrity: sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.27.4':
     resolution: {integrity: sha512-3j4jx1TppORdTAoBJRd+/wJRGCPC0ETWkXOecJ6PPZLj6SptXkrXcNqdj0oclbKML6FkQltdz7bBA3rUSirZug==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.30.1':
+    resolution: {integrity: sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==}
     cpu: [x64]
     os: [win32]
 
@@ -1271,8 +1366,8 @@ packages:
   '@ts-morph/common@0.26.0':
     resolution: {integrity: sha512-/RmKAtctStXqM5nECMQ46duT74Hoig/DBzhWXGHcodlDNrgRbsbwwHqSKFNbca6z9Xt/CUWMeXOsC9QEN1+rqw==}
 
-  '@types/aws-lambda@8.10.145':
-    resolution: {integrity: sha512-dtByW6WiFk5W5Jfgz1VM+YPA21xMXTuSFoLYIDY0L44jDLLflVPtZkYuu3/YxpGcvjzKFBZLU+GyKjR0HOYtyw==}
+  '@types/aws-lambda@8.10.147':
+    resolution: {integrity: sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==}
 
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
@@ -1298,8 +1393,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.10.5':
-    resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
+  '@types/node@22.10.7':
+    resolution: {integrity: sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg==}
 
   '@types/semver@7.5.8':
     resolution: {integrity: sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==}
@@ -1574,8 +1669,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  bundle-require@5.0.0:
-    resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
@@ -1634,6 +1729,10 @@ packages:
     resolution: {integrity: sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==}
     engines: {node: '>= 14.16.0'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -1677,8 +1776,8 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
-  consola@3.2.3:
-    resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
+  consola@3.4.0:
+    resolution: {integrity: sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   cookie@0.6.0:
@@ -1795,8 +1894,8 @@ packages:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  es-module-lexer@1.5.4:
-    resolution: {integrity: sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==}
+  es-module-lexer@1.6.0:
+    resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1876,6 +1975,9 @@ packages:
   esm-env@1.2.1:
     resolution: {integrity: sha512-U9JedYYjCnadUlXk7e1Kr+aENQhtUaoaV9+gZm1T8LC/YBAPJx3NSPIAurFOC0U5vrdSevnUJS2/wUVxGwPhng==}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1939,14 +2041,18 @@ packages:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.0.3:
-    resolution: {integrity: sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==}
+  fast-uri@3.0.5:
+    resolution: {integrity: sha512-5JnBCWpFlMo0a3ciDy/JckMzzv1U9coZrIhedq+HXxxUfDTAiS0LA8OKVao4G9BxmCVck/jtA5r3KAtRWEyD8Q==}
 
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -2291,6 +2397,9 @@ packages:
   magic-string@0.30.15:
     resolution: {integrity: sha512-zXeaYRgZ6ldS1RJJUrMrYgNJ4fdwnyI6tVqoiIhyCyv5IVTK9BU8Ic2l253GGETQHxI4HNUwhJ3fjDhKqEoaAw==}
 
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
   mdast-util-to-hast@13.2.0:
     resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
 
@@ -2365,6 +2474,11 @@ packages:
 
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.8:
+    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2643,6 +2757,10 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.1:
+    resolution: {integrity: sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -2704,6 +2822,10 @@ packages:
     resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
     engines: {node: '>= 14.16.0'}
 
+  readdirp@4.1.1:
+    resolution: {integrity: sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==}
+    engines: {node: '>= 14.18.0'}
+
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -2745,6 +2867,11 @@ packages:
 
   rollup@4.27.4:
     resolution: {integrity: sha512-RLKxqHEMjh/RGLsDxAEsaLO3mWgyoU6x9w6n1ikAzet4B3gI2/3yP6PWY2p9QzRTh6MfEIXB3MwsOY0Iv3vNrw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.30.1:
+    resolution: {integrity: sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -2914,6 +3041,10 @@ packages:
     resolution: {integrity: sha512-8wecoY1/1H3s2RlqXtbB66cyJk/wA7zG+urj0NkdSsLdX+pzrt47SeSv/viOMoGYlrEqJNsIakcGi0Qdu3qvoQ==}
     engines: {node: '>=18'}
 
+  svelte@5.18.0:
+    resolution: {integrity: sha512-/Eb81lB8bVUxQPmkPVNBYrU9cZ544+9hE91ZUUXTMf7eWcGW84N1hS3gvv/XsUNOWLLg3IicXP2qa8W3KpTUHA==}
+    engines: {node: '>=18'}
+
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
@@ -2954,8 +3085,8 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.1:
-    resolution: {integrity: sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==}
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
@@ -3044,8 +3175,8 @@ packages:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
-  type-fest@4.28.0:
-    resolution: {integrity: sha512-jXMwges/FVbFRe5lTMJZVEZCrO9kI9c8k0PA/z7nF3bo0JSCCLysvokFjNPIUK/itEMas10MQM+AiHoHt/T/XA==}
+  type-fest@4.32.0:
+    resolution: {integrity: sha512-rfgpoi08xagF3JSdtJlCwMq9DGNDE0IMh3Mkpc1wUypg9vPi786AiqeBBKcqvIkq42azsBM85N490fyZjeUftw==}
     engines: {node: '>=16'}
 
   typescript-eslint@8.20.0:
@@ -3283,8 +3414,8 @@ packages:
   whatwg-url@7.1.0:
     resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
-  when-exit@2.1.3:
-    resolution: {integrity: sha512-uVieSTccFIr/SFQdFWN/fFaQYmV37OKtuaGphMAzi4DmmUlrvRBJW5WSLkHyjNQY/ePJMz3LoiX9R3yy1Su6Hw==}
+  when-exit@2.1.4:
+    resolution: {integrity: sha512-4rnvd3A1t16PWzrBUcSDZqcAmsUIy4minDXT/CZ8F2mVDgd65i4Aalimgz1aQkRGU0iH5eT5+6Rx2TK8o443Pg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -3351,22 +3482,22 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
   '@babel/helper-string-parser@7.25.9': {}
 
   '@babel/helper-validator-identifier@7.25.9': {}
 
-  '@babel/parser@7.26.2':
+  '@babel/parser@7.26.5':
     dependencies:
-      '@babel/types': 7.26.0
+      '@babel/types': 7.26.5
 
   '@babel/runtime@7.26.0':
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/types@7.26.0':
+  '@babel/types@7.26.5':
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
@@ -3868,7 +3999,7 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
-  '@jridgewell/gen-mapping@0.3.5':
+  '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -3910,7 +4041,7 @@ snapshots:
 
   '@mapbox/node-pre-gyp@2.0.0-rc.0':
     dependencies:
-      consola: 3.2.3
+      consola: 3.4.0
       detect-libc: 2.0.3
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
@@ -4020,9 +4151,9 @@ snapshots:
       before-after-hook: 3.0.2
       universal-user-agent: 7.0.2
 
-  '@octokit/endpoint@10.1.1':
+  '@octokit/endpoint@10.1.2':
     dependencies:
-      '@octokit/types': 13.6.2
+      '@octokit/types': 13.7.0
       universal-user-agent: 7.0.2
 
   '@octokit/endpoint@9.0.5':
@@ -4050,7 +4181,7 @@ snapshots:
       '@octokit/core': 6.1.3
       '@octokit/oauth-authorization-url': 7.1.1
       '@octokit/oauth-methods': 5.1.3
-      '@types/aws-lambda': 8.10.145
+      '@types/aws-lambda': 8.10.147
       universal-user-agent: 7.0.2
 
   '@octokit/oauth-authorization-url@7.1.1': {}
@@ -4126,7 +4257,7 @@ snapshots:
 
   '@octokit/request@9.1.4':
     dependencies:
-      '@octokit/endpoint': 10.1.1
+      '@octokit/endpoint': 10.1.2
       '@octokit/request-error': 6.1.6
       '@octokit/types': 13.7.0
       fast-content-type-parse: 2.0.1
@@ -4157,66 +4288,123 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
-  '@rollup/pluginutils@5.1.3(rollup@4.27.4)':
+  '@rollup/pluginutils@5.1.3(rollup@4.30.1)':
     dependencies:
       '@types/estree': 1.0.6
       estree-walker: 2.0.2
       picomatch: 4.0.2
     optionalDependencies:
-      rollup: 4.27.4
+      rollup: 4.30.1
 
   '@rollup/rollup-android-arm-eabi@4.27.4':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.30.1':
     optional: true
 
   '@rollup/rollup-android-arm64@4.27.4':
     optional: true
 
+  '@rollup/rollup-android-arm64@4.30.1':
+    optional: true
+
   '@rollup/rollup-darwin-arm64@4.27.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.30.1':
     optional: true
 
   '@rollup/rollup-darwin-x64@4.27.4':
     optional: true
 
+  '@rollup/rollup-darwin-x64@4.30.1':
+    optional: true
+
   '@rollup/rollup-freebsd-arm64@4.27.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.30.1':
     optional: true
 
   '@rollup/rollup-freebsd-x64@4.27.4':
     optional: true
 
+  '@rollup/rollup-freebsd-x64@4.30.1':
+    optional: true
+
   '@rollup/rollup-linux-arm-gnueabihf@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.30.1':
     optional: true
 
   '@rollup/rollup-linux-arm-musleabihf@4.27.4':
     optional: true
 
+  '@rollup/rollup-linux-arm-musleabihf@4.30.1':
+    optional: true
+
   '@rollup/rollup-linux-arm64-gnu@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.30.1':
     optional: true
 
   '@rollup/rollup-linux-arm64-musl@4.27.4':
     optional: true
 
+  '@rollup/rollup-linux-arm64-musl@4.30.1':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.30.1':
+    optional: true
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.30.1':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.27.4':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.30.1':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.30.1':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.27.4':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.30.1':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.27.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.30.1':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.27.4':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.30.1':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.27.4':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.30.1':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.27.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.30.1':
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -4258,19 +4446,19 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)))(rollup@4.27.4)':
+  '@sveltejs/adapter-vercel@5.5.2(@sveltejs/kit@2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)))(rollup@4.30.1)':
     dependencies:
-      '@sveltejs/kit': 2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))
-      '@vercel/nft': 0.27.9(rollup@4.27.4)
+      '@sveltejs/kit': 2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))
+      '@vercel/nft': 0.27.9(rollup@4.30.1)
       esbuild: 0.24.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))':
+  '@sveltejs/kit@2.15.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 5.1.1
@@ -4284,27 +4472,27 @@ snapshots:
       sirv: 3.0.0
       svelte: 5.17.5
       tiny-glob: 0.2.9
-      vite: 6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)
+      vite: 6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte': 5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))
       debug: 4.4.0
       svelte: 5.17.5
-      vite: 6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)
+      vite: 6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))':
+  '@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)))(svelte@5.17.5)(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))
       debug: 4.4.0
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.15
       svelte: 5.17.5
-      vite: 6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)
-      vitefu: 1.0.4(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1))
+      vite: 6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)
+      vitefu: 1.0.4(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -4322,11 +4510,11 @@ snapshots:
 
   '@ts-morph/common@0.26.0':
     dependencies:
-      fast-glob: 3.3.2
+      fast-glob: 3.3.3
       minimatch: 9.0.5
       path-browserify: 1.0.1
 
-  '@types/aws-lambda@8.10.145': {}
+  '@types/aws-lambda@8.10.147': {}
 
   '@types/cookie@0.6.0': {}
 
@@ -4351,7 +4539,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.10.5':
+  '@types/node@22.10.7':
     dependencies:
       undici-types: 6.20.0
 
@@ -4440,10 +4628,10 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vercel/nft@0.27.9(rollup@4.27.4)':
+  '@vercel/nft@0.27.9(rollup@4.30.1)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.0-rc.0
-      '@rollup/pluginutils': 5.1.3(rollup@4.27.4)
+      '@rollup/pluginutils': 5.1.3(rollup@4.30.1)
       acorn: 8.14.0
       acorn-import-attributes: 1.9.5(acorn@8.14.0)
       async-sema: 3.1.1
@@ -4466,13 +4654,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.5))':
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.7))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
-      magic-string: 0.30.15
+      magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.5)
+      vite: 5.4.11(@types/node@22.10.7)
 
   '@vitest/pretty-format@2.1.8':
     dependencies:
@@ -4486,7 +4674,7 @@ snapshots:
   '@vitest/snapshot@2.1.8':
     dependencies:
       '@vitest/pretty-format': 2.1.8
-      magic-string: 0.30.15
+      magic-string: 0.30.17
       pathe: 1.1.2
 
   '@vitest/spy@2.1.8':
@@ -4501,7 +4689,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.26.2
+      '@babel/parser': 7.26.5
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -4514,14 +4702,14 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.26.2
+      '@babel/parser': 7.26.5
       '@vue/compiler-core': 3.5.13
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-ssr': 3.5.13
       '@vue/shared': 3.5.13
       estree-walker: 2.0.2
-      magic-string: 0.30.15
-      postcss: 8.4.49
+      magic-string: 0.30.17
+      postcss: 8.5.1
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.13':
@@ -4585,7 +4773,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.3
+      fast-uri: 3.0.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4627,7 +4815,7 @@ snapshots:
   atomically@2.0.3:
     dependencies:
       stubborn-fs: 1.2.5
-      when-exit: 2.1.3
+      when-exit: 2.1.4
 
   autoprefixer@10.4.20(postcss@8.4.49):
     dependencies:
@@ -4689,9 +4877,9 @@ snapshots:
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
 
-  bundle-require@5.0.0(esbuild@0.24.0):
+  bundle-require@5.1.0(esbuild@0.24.2):
     dependencies:
-      esbuild: 0.24.0
+      esbuild: 0.24.2
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
@@ -4745,6 +4933,10 @@ snapshots:
     dependencies:
       readdirp: 4.0.2
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.1
+
   chownr@3.0.0: {}
 
   ci-info@3.9.0: {}
@@ -4781,7 +4973,7 @@ snapshots:
 
   confbox@0.1.8: {}
 
-  consola@3.2.3: {}
+  consola@3.4.0: {}
 
   cookie@0.6.0: {}
 
@@ -4839,7 +5031,7 @@ snapshots:
 
   dot-prop@9.0.0:
     dependencies:
-      type-fest: 4.28.0
+      type-fest: 4.32.0
 
   eastasianwidth@0.2.0: {}
 
@@ -4860,7 +5052,7 @@ snapshots:
 
   env-paths@3.0.0: {}
 
-  es-module-lexer@1.5.4: {}
+  es-module-lexer@1.6.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -5034,6 +5226,8 @@ snapshots:
 
   esm-env@1.2.1: {}
 
+  esm-env@1.2.2: {}
+
   espree@10.3.0:
     dependencies:
       acorn: 8.14.0
@@ -5107,11 +5301,19 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.0.3: {}
+  fast-uri@3.0.5: {}
 
   fastq@1.17.1:
     dependencies:
@@ -5430,6 +5632,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   mdast-util-to-hast@13.2.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -5509,6 +5715,8 @@ snapshots:
       thenify-all: 1.6.0
 
   nanoid@3.3.7: {}
+
+  nanoid@3.3.8: {}
 
   natural-compare@1.4.0: {}
 
@@ -5698,12 +5906,12 @@ snapshots:
     optionalDependencies:
       postcss: 8.4.49
 
-  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.49)(yaml@2.6.1):
+  postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.5.1)(yaml@2.6.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.6
-      postcss: 8.4.49
+      postcss: 8.5.1
       yaml: 2.6.1
 
   postcss-nested@6.2.0(postcss@8.4.49):
@@ -5734,6 +5942,12 @@ snapshots:
   postcss@8.4.49:
     dependencies:
       nanoid: 3.3.7
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.1:
+    dependencies:
+      nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -5792,6 +6006,8 @@ snapshots:
 
   readdirp@4.0.2: {}
 
+  readdirp@4.1.1: {}
+
   regenerator-runtime@0.14.1: {}
 
   regex-recursion@5.1.1:
@@ -5847,6 +6063,31 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.27.4
       '@rollup/rollup-win32-ia32-msvc': 4.27.4
       '@rollup/rollup-win32-x64-msvc': 4.27.4
+      fsevents: 2.3.3
+
+  rollup@4.30.1:
+    dependencies:
+      '@types/estree': 1.0.6
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.30.1
+      '@rollup/rollup-android-arm64': 4.30.1
+      '@rollup/rollup-darwin-arm64': 4.30.1
+      '@rollup/rollup-darwin-x64': 4.30.1
+      '@rollup/rollup-freebsd-arm64': 4.30.1
+      '@rollup/rollup-freebsd-x64': 4.30.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.30.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.30.1
+      '@rollup/rollup-linux-arm64-gnu': 4.30.1
+      '@rollup/rollup-linux-arm64-musl': 4.30.1
+      '@rollup/rollup-linux-loongarch64-gnu': 4.30.1
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.30.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.30.1
+      '@rollup/rollup-linux-s390x-gnu': 4.30.1
+      '@rollup/rollup-linux-x64-gnu': 4.30.1
+      '@rollup/rollup-linux-x64-musl': 4.30.1
+      '@rollup/rollup-win32-arm64-msvc': 4.30.1
+      '@rollup/rollup-win32-ia32-msvc': 4.30.1
+      '@rollup/rollup-win32-x64-msvc': 4.30.1
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -5961,7 +6202,7 @@ snapshots:
 
   sucrase@3.35.0:
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/gen-mapping': 0.3.8
       commander: 4.1.1
       glob: 10.4.5
       lines-and-columns: 1.2.4
@@ -6022,6 +6263,23 @@ snapshots:
       is-reference: 3.0.3
       locate-character: 3.0.0
       magic-string: 0.30.15
+      zimmerframe: 1.1.2
+
+  svelte@5.18.0:
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@types/estree': 1.0.6
+      acorn: 8.14.0
+      acorn-typescript: 1.4.13(acorn@8.14.0)
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      esm-env: 1.2.2
+      esrap: 1.4.3
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.17
       zimmerframe: 1.1.2
 
   tailwind-merge@2.6.0: {}
@@ -6088,7 +6346,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.1: {}
+  tinyexec@0.3.2: {}
 
   tinyglobby@0.2.10:
     dependencies:
@@ -6136,26 +6394,26 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.3.5(jiti@1.21.6)(postcss@8.4.49)(typescript@5.7.3)(yaml@2.6.1):
+  tsup@8.3.5(jiti@1.21.6)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.6.1):
     dependencies:
-      bundle-require: 5.0.0(esbuild@0.24.0)
+      bundle-require: 5.1.0(esbuild@0.24.2)
       cac: 6.7.14
-      chokidar: 4.0.1
-      consola: 3.2.3
+      chokidar: 4.0.3
+      consola: 3.4.0
       debug: 4.4.0
-      esbuild: 0.24.0
+      esbuild: 0.24.2
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.49)(yaml@2.6.1)
+      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.5.1)(yaml@2.6.1)
       resolve-from: 5.0.0
-      rollup: 4.27.4
+      rollup: 4.30.1
       source-map: 0.8.0-beta.0
       sucrase: 3.35.0
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       tinyglobby: 0.2.10
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.4.49
+      postcss: 8.5.1
       typescript: 5.7.3
     transitivePeerDependencies:
       - jiti
@@ -6169,7 +6427,7 @@ snapshots:
 
   type-detect@4.1.0: {}
 
-  type-fest@4.28.0: {}
+  type-fest@4.32.0: {}
 
   typescript-eslint@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.7.3):
     dependencies:
@@ -6262,13 +6520,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@2.1.8(@types/node@22.10.5):
+  vite-node@2.1.8(@types/node@22.10.7):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
-      es-module-lexer: 1.5.4
+      es-module-lexer: 1.6.0
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.10.5)
+      vite: 5.4.11(@types/node@22.10.7)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6280,34 +6538,34 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.11(@types/node@22.10.5):
+  vite@5.4.11(@types/node@22.10.7):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.27.4
+      postcss: 8.5.1
+      rollup: 4.30.1
     optionalDependencies:
-      '@types/node': 22.10.5
+      '@types/node': 22.10.7
       fsevents: 2.3.3
 
-  vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1):
+  vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.4.49
       rollup: 4.27.4
     optionalDependencies:
-      '@types/node': 22.10.5
+      '@types/node': 22.10.7
       fsevents: 2.3.3
       jiti: 1.21.6
       yaml: 2.6.1
 
-  vitefu@1.0.4(vite@6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)):
+  vitefu@1.0.4(vite@6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)):
     optionalDependencies:
-      vite: 6.0.7(@types/node@22.10.5)(jiti@1.21.6)(yaml@2.6.1)
+      vite: 6.0.7(@types/node@22.10.7)(jiti@1.21.6)(yaml@2.6.1)
 
-  vitest@2.1.8(@types/node@22.10.5):
+  vitest@2.1.8(@types/node@22.10.7):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.5))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.7))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -6316,18 +6574,18 @@ snapshots:
       chai: 5.1.2
       debug: 4.4.0
       expect-type: 1.1.0
-      magic-string: 0.30.15
+      magic-string: 0.30.17
       pathe: 1.1.2
       std-env: 3.8.0
       tinybench: 2.9.0
-      tinyexec: 0.3.1
+      tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.10.5)
-      vite-node: 2.1.8(@types/node@22.10.5)
+      vite: 5.4.11(@types/node@22.10.7)
+      vite-node: 2.1.8(@types/node@22.10.7)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.10.5
+      '@types/node': 22.10.7
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -6366,7 +6624,7 @@ snapshots:
       tr46: 1.0.1
       webidl-conversions: 4.0.2
 
-  when-exit@2.1.3: {}
+  when-exit@2.1.4: {}
 
   which@2.0.2:
     dependencies:

--- a/sites/docs/src/lib/map.ts
+++ b/sites/docs/src/lib/map.ts
@@ -105,7 +105,7 @@ const categories: Category[] = [
 				href: '/docs/language-support'
 			},
 			{
-				name: 'Git Providers',
+				name: 'Providers',
 				href: '/docs/git-providers',
 				activeForSubdirectories: true,
 				routes: [
@@ -128,6 +128,10 @@ const categories: Category[] = [
 						name: 'AzureDevops',
 						href: '/docs/git-providers/azure-devops',
 						icon: Icons.AzureDevops
+					},
+					{
+						name: 'Self Hosted',
+						href: '/docs/git-providers/self-hosted'
 					}
 				]
 			},

--- a/sites/docs/src/routes/docs/cli/build/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/build/+page.svelte
@@ -23,6 +23,20 @@
 		<Snippet command="execute" args={['jsrepo', 'build', '--dirs', './src', './blocks']} />
 	{/snippet}
 </OptionDocs>
+<OptionDocs name="--output-dir">
+	{#snippet description()}
+		Directory to copy the <CodeSpan>jsrepo-manifest.json</CodeSpan> and all required registry files to
+		once the build is complete. This is useful when you want to host your registry on a custom domain
+		from a different directory from where the code actually lives. Corresponding config key: <Link
+			href="/docs/jsrepo-build-config-json#outputDir"
+		>
+			outputDir
+		</Link>
+	{/snippet}
+	{#snippet usage()}
+		<Snippet command="execute" args={['jsrepo', 'build', '--output-dir', './static/new-york']} />
+	{/snippet}
+</OptionDocs>
 <OptionDocs name="--include-blocks">
 	{#snippet description()}
 		Include only the blocks with these names. Corresponding config key: <Link

--- a/sites/docs/src/routes/docs/git-providers/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/+page.svelte
@@ -35,6 +35,11 @@
 			name: 'AzureDevops',
 			href: '/docs/git-providers/azure-devops',
 			status: '⚠️'
+		},
+		{
+			name: 'Self Hosted',
+			href: '/docs/git-providers/self-hosted',
+			status: '✅'
 		}
 	];
 </script>
@@ -62,7 +67,7 @@
 	description="Git Providers that jsrepo supports in your registry."
 />
 <p>
-	<Jsrepo /> has to resolve paths to git providers meaning they must be explicity supported.
+	<Jsrepo /> supports a variety of git providers as well as custom urls.
 </p>
 <div class="flex flex-col gap-1">
 	<span>Legend:</span>

--- a/sites/docs/src/routes/docs/git-providers/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/+page.svelte
@@ -67,7 +67,7 @@
 	description="Git Providers that jsrepo supports in your registry."
 />
 <p>
-	<Jsrepo /> supports a variety of git providers as well as custom urls.
+	<Jsrepo /> supports a variety of registry providers as well as custom urls.
 </p>
 <div class="flex flex-col gap-1">
 	<span>Legend:</span>

--- a/sites/docs/src/routes/docs/git-providers/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/+page.svelte
@@ -64,10 +64,10 @@
 
 <DocHeader
 	title="Git Providers"
-	description="Git Providers that jsrepo supports in your registry."
+	description="Providers that jsrepo supports for serving your registry."
 />
 <p>
-	<Jsrepo /> supports a variety of registry providers as well as custom urls.
+	<Jsrepo /> supports a variety of git providers as well as custom urls.
 </p>
 <div class="flex flex-col gap-1">
 	<span>Legend:</span>

--- a/sites/docs/src/routes/docs/git-providers/self-hosted/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/self-hosted/+page.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+	import { DocHeader, Jsrepo } from '$lib/components/site/docs';
+	import { Code } from '$lib/components/ui/code';
+	import CodeSpan from '$lib/components/site/docs/code-span.svelte';
+	import { Snippet } from '$lib/components/ui/snippet';
+</script>
+
+<DocHeader title="Self Hosted" description="How to self host a jsrepo registry." />
+<p>
+	<Jsrepo /> enables self hosting your registry on the web. This can allow for more customization of
+	exactly how things are served. As well as enabling you to do things like distributing your registry
+	on a private network.
+</p>
+<p>
+	You can start hosting your own registry by building the <CodeSpan>jsrepo-manifest.json</CodeSpan> at
+	the root of where your blocks are hosted.
+</p>
+<p>For example in a SvelteKit app:</p>
+<Code
+	hideLines
+	code={`root
+├── .svelte-kit
+├── src
+├── static
+│   ├── blocks
+│   │   └── ...
+│   └── jsrepo-manifest.json
+├── .gitignore
+├── .npmrc
+├── package.json
+├── svelte.config.js
+├── tsconfig.json
+└── vite.config.ts`}
+/>
+<p>Here we put the blocks directly in the static directory so that you simply access them with:</p>
+<Snippet command="execute" args={['jsrepo', 'add', '--repo', 'https://example.com/']} />
+<p>
+	You can also customize where blocks are served. You just need to tell jsrepo where the
+	<CodeSpan>jsrepo-manifest.json</CodeSpan> is.
+</p>
+<Code
+	hideLines
+	code={`root
+├── ...
+├── static
+│	├── default
+│	│	├── ...
+│	│   └── jsrepo-manifest.json
+│	└── new-york
+│		├── ...
+│		└── jsrepo-manifest.json
+└──  ...`}
+/>
+<p>
+	Now users can access blocks from either <CodeSpan>https://example.com/default</CodeSpan> or
+	<CodeSpan>https://example.com/new-york</CodeSpan>:
+</p>
+<Snippet command="execute" args={['jsrepo', 'add', '--repo', 'https://example.com/default']} />
+<p>You can still add fully qualified blocks but as always the path must be complete:</p>
+<Snippet
+	command="execute"
+	args={['jsrepo', 'add', '--repo', 'https://example.com/default/ui/accordion']}
+/>

--- a/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
+++ b/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
@@ -39,6 +39,21 @@
     ]
 }`}
 />
+<SubHeading>outputDir</SubHeading>
+<p>
+	<CodeSpan>outputDir</CodeSpan> is an optional key that allows you to copy the resulting
+	<CodeSpan>jsrepo-manifest.json</CodeSpan> and any required files to a custom directory.
+</p>
+<p>
+	This is useful if you want to host the registry in a different location from where the code
+	actually lives. (This should NOT be used when hosting your registry from a git repository)
+</p>
+<Code
+	lang="json"
+	code={`{
+    "outputDir": "./static/new-york"
+}`}
+/>
 <SubHeading>listBlocks</SubHeading>
 <p>
 	<CodeSpan>listBlocks</CodeSpan> is a list of block names that should be listed when the user runs the

--- a/sites/docs/static/docs/cli/llms.txt
+++ b/sites/docs/static/docs/cli/llms.txt
@@ -2,7 +2,7 @@
 
 > A CLI to add shared code from remote repositories.
  
-Latest Version: 1.24.3
+Latest Version: 1.25.0
 
 ## Commands
 

--- a/sites/docs/static/docs/cli/llms.txt
+++ b/sites/docs/static/docs/cli/llms.txt
@@ -47,6 +47,7 @@ jsrepo build [options]
 
 #### Options
 - --dirs [dirs...]: The directories containing the blocks. 
+- --output-dir <dir>: The directory to output the registry to. (Copies jsrepo-manifest.json + all required files) 
 - --include-blocks [blockNames...]: Include only the blocks with these names. 
 - --include-categories [categoryNames...]: Include only the categories with these names. 
 - --exclude-blocks [blockNames...]: Do not include the blocks with these names. 

--- a/sites/docs/static/llms.txt
+++ b/sites/docs/static/llms.txt
@@ -6,9 +6,9 @@
 
 - [jsrepo CLI](https://jsrepo.dev/docs/cli/llms.txt)
 
-## Git Provider Support
+## Provider Support
 
-jsrepo supports GitHub, GitLab, BitBucket, and Azure DevOps
+jsrepo supports multiple ways of serving your registry, you can host your registry on GitHub, GitLab, BitBucket, Azure DevOps or on your own domain.
 
 ## Language Support
 


### PR DESCRIPTION
This PR adds support for downloading from an arbitrary url. This approach can allow users with more specialized use cases to customize the way that users download blocks. This can also allow for local testing of registries so long as you can keep a server running.

Now you can download from a url by pointing to the path containing the jsrepo-manifest.json:
```bash
jsrepo init https://example.com/ # served from ./
jsrepo add https://example.com/utils/add

jsrepo init https://example.com/new-york # served from ./new-york
jsrepo add https://example.com/new-york/ui/accordion
```

## Additional Changes
- When adding fully qualified blocks from a repo not included in config the config repos will no longer be fetched
- When adding blocks with zero-config you will now be prompted before overwriting an existing block
- Adds a `outputDir` key to build config to allow you to copy the entire registry to the `outputDir` when supplied.

## Docs
- Add new `self-hosted` section to the providers section