### PR TITLE
fix: Ensure urls with or without a trailing slash are treated the same

### DIFF
--- a/.changeset/happy-chairs-suffer.md
+++ b/.changeset/happy-chairs-suffer.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Ensure urls with or without a trailing slash are treated the same.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,12 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": "./dist/index.js",
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/utils/blocks.ts
+++ b/packages/cli/src/utils/blocks.ts
@@ -7,6 +7,7 @@ import { mapToArray } from './blocks/utils/map-to-array';
 import type { Block } from './build';
 import { type ProjectConfig, resolvePaths } from './config';
 import * as providers from './providers';
+import { removeTrailingSlash } from './url';
 
 export type RemoteBlock = Block & { sourceRepo: providers.Info };
 
@@ -143,13 +144,7 @@ const getInstalled = (
 };
 
 const fullyQualifiedName = (url: string, category: string, name: string) => {
-	let normalizedUrl = url;
-
-	if (normalizedUrl.endsWith('/')) {
-		normalizedUrl = normalizedUrl.slice(0, normalizedUrl.length - 1);
-	}
-
-	return `${normalizedUrl}/${category}/${name}`;
+	return `${removeTrailingSlash(url)}/${category}/${name}`;
 };
 
 export { resolveTree, getInstalled, fullyQualifiedName };

--- a/packages/cli/src/utils/providers.ts
+++ b/packages/cli/src/utils/providers.ts
@@ -7,6 +7,7 @@ import { Err, Ok, type Result } from './blocks/types/result';
 import { type Category, categorySchema } from './build';
 import { OUTPUT_FILE } from './context';
 import * as persisted from './persisted';
+import { addTrailingSlash, removeTrailingSlash } from './url';
 
 export type Info = {
 	refs: 'tags' | 'heads';
@@ -640,7 +641,7 @@ const http: Provider = {
 
 		return {
 			name: http.name(),
-			url: path,
+			url: addTrailingSlash(path),
 			provider: http,
 
 			// nothing else is important

--- a/packages/cli/src/utils/url.ts
+++ b/packages/cli/src/utils/url.ts
@@ -1,0 +1,17 @@
+export const removeTrailingSlash = (url: string): string => {
+	let newUrl = url;
+	if (newUrl.endsWith('/')) {
+		newUrl = newUrl.slice(0, newUrl.length - 1);
+	}
+
+	return newUrl;
+};
+
+export const addTrailingSlash = (url: string): string => {
+	let newUrl = url;
+	if (!newUrl.endsWith('/')) {
+		newUrl = `${newUrl}/`;
+	}
+
+	return newUrl;
+};


### PR DESCRIPTION
Previously when resolving raw urls the `new URL()` constructor incorrectly handling urls that don't have a trailing slash. 

I think this is a pretty stupid behavior but basically it does this:
```ts
new URL('test.js', 'https://x.com/default'); // -> https://x.com/test.js
new URL('test.js', 'https://x.com/default/'); // -> https://x.com/default/test.js
```

This PR adds the trailing slash when we parse the url to ensure that it is handled correctly.
