### PR TITLE
feat: Expose registry types

### DIFF
--- a/.changeset/thin-zoos-confess.md
+++ b/.changeset/thin-zoos-confess.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Expose registry types.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,24 +15,21 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
-	"exports": "./dist/index.js",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"default": "./dist/index.js"
+		},
+		"./registry": {
+			"types": "./dist/registry/index.d.ts",
+			"default": "./dist/registry/index.js"
+		}
+	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -1,5 +1,5 @@
 import type { Block, Category } from '../utils/build';
-import type { RegistryConfig, ProjectConfig } from '../utils/config';
+import type { ProjectConfig, RegistryConfig } from '../utils/config';
 
 type Manifest = Category[];
 

--- a/packages/cli/src/registry/index.ts
+++ b/packages/cli/src/registry/index.ts
@@ -1,0 +1,6 @@
+import type { Block, Category } from '../utils/build';
+import type { RegistryConfig, ProjectConfig } from '../utils/config';
+
+type Manifest = Category[];
+
+export type { Block, Category, Manifest, RegistryConfig, ProjectConfig };

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-	entry: ['src/index.ts'],
+	entry: ['src/index.ts', 'src/registry/index.ts'],
 	format: ['esm'],
 	platform: 'node',
 	target: 'es2022',
@@ -10,7 +10,8 @@ export default defineConfig({
 	minify: true,
 	treeshake: true,
 	splitting: true,
-	dts: false,
+	sourcemap: true,
+	dts: true,
 	banner: {
 		js: '#!/usr/bin/env node',
 	},


### PR DESCRIPTION
This will provide the basic types needed for working with the manifest and config files. Could be useful for any sort of tooling build around jsrepo.