### PR TITLE
fix: prevent urls from being cut short in http provider

### DIFF
--- a/.changeset/breezy-papayas-grab.md
+++ b/.changeset/breezy-papayas-grab.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Ensure parsed urls from http provider end with a trailing slash.

--- a/.changeset/lazy-coins-admire.md
+++ b/.changeset/lazy-coins-admire.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Catch `JSON.parse` errors when fetching the manifest to provide a more clear error to the user.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": {
 		".": {
@@ -34,10 +25,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -33,7 +33,6 @@ import { loadFormatterConfig } from '../utils/format';
 import { json } from '../utils/language-support';
 import * as persisted from '../utils/persisted';
 import { type Task, intro, nextSteps, runTasks } from '../utils/prompts';
-import { http, providers } from '../utils/registry-providers';
 import * as registry from '../utils/registry-providers/internal';
 
 const schema = v.object({
@@ -199,8 +198,8 @@ const _initProject = async (registries: string[], options: Options) => {
 			validate: (val) => {
 				if (val.trim().length === 0) return 'Please provide a value';
 
-				if (!providers.find((provider) => provider.matches(val))) {
-					return `Invalid provider! Valid providers (${providers.map((provider) => provider.name).join(', ')})`;
+				if (!registry.selectProvider(val)) {
+					return `Invalid provider! Valid providers (${registry.providers.map((provider) => provider.name).join(', ')})`;
 				}
 			},
 		});
@@ -290,12 +289,12 @@ const promptForProviderConfig = async (repo: string, paths: Paths): Promise<Path
 
 	const storage = persisted.get();
 
-	const provider = providers.find((p) => p.matches(repo));
+	const provider = registry.selectProvider(repo);
 
 	if (!provider) {
 		program.error(
 			color.red(
-				`Invalid provider! Valid providers (${providers.map((provider) => provider.name).join(', ')})`
+				`Invalid provider! Valid providers (${registry.providers.map((provider) => provider.name).join(', ')})`
 			)
 		);
 	}
@@ -305,7 +304,7 @@ const promptForProviderConfig = async (repo: string, paths: Paths): Promise<Path
 	const token = storage.get(tokenKey);
 
 	// don't ask if the provider is a custom domain
-	if (!token && provider.name !== http.name) {
+	if (!token && provider.name !== registry.http.name) {
 		const result = await confirm({
 			message: 'Would you like to add an auth token?',
 			initialValue: false,

--- a/packages/cli/src/utils/registry-providers/http.ts
+++ b/packages/cli/src/utils/registry-providers/http.ts
@@ -75,7 +75,7 @@ const parseUrl = (
 	}
 
 	return {
-		url: u.join(parsedUrl.origin, ...segments),
+		url: u.addTrailingSlash(u.join(parsedUrl.origin, ...segments)),
 		specifier,
 	};
 };

--- a/packages/cli/src/utils/registry-providers/index.ts
+++ b/packages/cli/src/utils/registry-providers/index.ts
@@ -70,7 +70,15 @@ export const fetchManifest = async (
 
 	if (manifest.isErr()) return Err(manifest.unwrapErr());
 
-	const categories = v.safeParse(v.array(categorySchema), JSON.parse(manifest.unwrap()));
+	let json: string;
+
+	try {
+		json = JSON.parse(manifest.unwrap());
+	} catch (err) {
+		return Err(`Error parsing categories: ${err}`);
+	}
+
+	const categories = v.safeParse(v.array(categorySchema), json);
 
 	if (!categories.success) {
 		return Err(`Error parsing categories: ${categories.issues}`);

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, expect, it } from 'vitest';
+import { MANIFEST_FILE } from '../src/constants';
 import * as registry from '../src/utils/registry-providers/internal';
 import type { ParseOptions, ParseResult } from '../src/utils/registry-providers/types';
 
@@ -8,7 +9,7 @@ type ParseTestCase = {
 	expected: ParseResult;
 };
 
-type BaseUrlTestCase = {
+type StringTestCase = {
 	url: string;
 	expected: string;
 };
@@ -72,7 +73,7 @@ describe('github', () => {
 	});
 
 	it('correctly parses base url', () => {
-		const cases: BaseUrlTestCase[] = [
+		const cases: StringTestCase[] = [
 			{
 				url: 'github/ieedan/std',
 				expected: 'https://github.com/ieedan/std',
@@ -372,7 +373,7 @@ describe('gitlab', () => {
 	});
 
 	it('correctly parses base url', () => {
-		const cases: BaseUrlTestCase[] = [
+		const cases: StringTestCase[] = [
 			{
 				url: 'gitlab/ieedan/std',
 				expected: 'https://gitlab.com/ieedan/std',
@@ -648,7 +649,7 @@ describe('bitbucket', () => {
 	});
 
 	it('correctly parses base url', () => {
-		const cases: BaseUrlTestCase[] = [
+		const cases: StringTestCase[] = [
 			{
 				url: 'bitbucket/ieedan/std',
 				expected: 'https://bitbucket.org/ieedan/std',
@@ -916,7 +917,7 @@ describe('azure', () => {
 	});
 
 	it('correctly parses base url', () => {
-		const cases: BaseUrlTestCase[] = [
+		const cases: StringTestCase[] = [
 			{
 				url: 'azure/ieedan/std/std',
 				expected: 'https://dev.azure.com/ieedan/_git/std',
@@ -1144,7 +1145,7 @@ describe('http', () => {
 				url: 'https://example.com/',
 				opts: { fullyQualified: false },
 				expected: {
-					url: 'https://example.com',
+					url: 'https://example.com/',
 					specifier: undefined,
 				},
 			},
@@ -1152,7 +1153,7 @@ describe('http', () => {
 				url: 'https://example.com/new-york',
 				opts: { fullyQualified: false },
 				expected: {
-					url: 'https://example.com/new-york',
+					url: 'https://example.com/new-york/',
 					specifier: undefined,
 				},
 			},
@@ -1160,7 +1161,7 @@ describe('http', () => {
 				url: 'https://example.com/utils/math',
 				opts: { fullyQualified: true },
 				expected: {
-					url: 'https://example.com',
+					url: 'https://example.com/',
 					specifier: 'utils/math',
 				},
 			},
@@ -1168,7 +1169,7 @@ describe('http', () => {
 				url: 'https://example.com/new-york/utils/math',
 				opts: { fullyQualified: true },
 				expected: {
-					url: 'https://example.com/new-york',
+					url: 'https://example.com/new-york/',
 					specifier: 'utils/math',
 				},
 			},
@@ -1179,8 +1180,31 @@ describe('http', () => {
 		}
 	});
 
+	it('correctly resolves url', async () => {
+		const cases: StringTestCase[] = [
+			{
+				url: 'https://example.com',
+				expected: 'https://example.com/jsrepo-manifest.json',
+			},
+			{
+				url: 'https://example.com/new-york',
+				expected: 'https://example.com/new-york/jsrepo-manifest.json',
+			},
+		];
+
+		for (const c of cases) {
+			const state = await registry.getProviderState(c.url);
+
+			assert(!state.isErr());
+
+			expect(
+				await state.unwrap().provider.resolveRaw(state.unwrap(), MANIFEST_FILE)
+			).toStrictEqual(new URL(c.expected));
+		}
+	});
+
 	it('correctly parses base url', () => {
-		const cases: BaseUrlTestCase[] = [
+		const cases: StringTestCase[] = [
 			{
 				url: 'https://example.com/',
 				expected: 'https://example.com',


### PR DESCRIPTION
Fixes https://github.com/DavidHDev/react-bits/issues/39

- Improve error given when `JSON.parse` fails in `fetchManifest`
- Add test cases

This was caused because the `URL` api is dumb.