### PR TITLE
fix: remove `meta.builtAt` from `jsrepo-manifest.json`

### DIFF
--- a/.changeset/gold-impalas-relax.md
+++ b/.changeset/gold-impalas-relax.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+Remove `meta.builtAt` key from `jsrepo-manifest.json`

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": {
 		".": {
@@ -34,10 +25,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -283,13 +283,8 @@ const _build = async (options: Options) => {
 };
 
 export const createManifest = (categories: Category[], config: RegistryConfig) => {
-	const meta = config.meta ?? {};
-
 	const manifest: Manifest = {
-		meta: {
-			builtAt: Date.now(),
-			...meta,
-		},
+		meta: config.meta,
 		categories,
 	};
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -21,7 +21,6 @@ export const categorySchema = v.object({
 });
 
 export const manifestMeta = v.object({
-	builtAt: v.number(),
 	authors: v.optional(v.array(v.string())),
 	bugs: v.optional(v.string()),
 	description: v.optional(v.string()),

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -52,7 +52,7 @@ export type Formatter = v.InferOutput<typeof formatterSchema>;
 
 const registryConfigSchema = v.object({
 	$schema: v.string(),
-	meta: v.optional(v.omit(manifestMeta, ['builtAt'])),
+	meta: v.optional(manifestMeta),
 	dirs: v.array(v.string()),
 	outputDir: v.optional(v.string()),
 	includeBlocks: v.optional(v.array(v.string()), []),


### PR DESCRIPTION
This was an oversight. It would be nice to have an `updated at` somewhere but this is clearly not the way to do it. Since the number will always be different a workflow will open a PR every time it changes. Not ideal.