### PR TITLE
feat: Subdirectories

### DIFF
--- a/.changeset/itchy-cycles-taste.md
+++ b/.changeset/itchy-cycles-taste.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+feat: Support for subdirectories 🎉

--- a/examples/registry/jsrepo-build-config.json
+++ b/examples/registry/jsrepo-build-config.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "../../packages/cli/schemas/registry-config.json",
+	"$schema": "https://unpkg.com/jsrepo@1.30.1/schemas/project-config.json",
 	"meta": {
 		"authors": ["Aidan Bleser"],
 		"description": "An example registry",

--- a/examples/registry/jsrepo-manifest.json
+++ b/examples/registry/jsrepo-manifest.json
@@ -1,6 +1,5 @@
 {
 	"meta": {
-		"builtAt": 1738589208370,
 		"authors": [
 			"Aidan Bleser"
 		],

--- a/packages/cli/jsrepo.json
+++ b/packages/cli/jsrepo.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://unpkg.com/jsrepo@1.24.3/schemas/project-config.json",
+	"$schema": "https://unpkg.com/jsrepo@1.30.1/schemas/project-config.json",
 	"repos": ["github/ieedan/std"],
 	"includeTests": false,
 	"watermark": true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
 		"@types/validate-npm-package-name": "^4.0.2",
 		"tsup": "^8.3.6",
 		"typescript": "^5.7.3",
-		"vitest": "^3.0.4"
+		"vitest": "^3.0.5"
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.36.3",
@@ -70,8 +70,8 @@
 		"parse5": "^7.2.1",
 		"pathe": "^2.0.2",
 		"prettier": "^3.4.2",
-		"semver": "^7.7.0",
-		"svelte": "^5.19.6",
+		"semver": "^7.7.1",
+		"svelte": "^5.19.7",
 		"ts-morph": "^25.0.0",
 		"valibot": "1.0.0-beta.14",
 		"validate-npm-package-name": "^6.0.0",

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -114,6 +114,11 @@
 				"type": "string"
 			}
 		},
+		"allowSubdirectories": {
+			"description": "Allow subdirectories to be built.",
+			"type": "boolean",
+			"default": false
+		},
 		"preview": {
 			"description": "Display a preview of the blocks list.",
 			"type": "boolean",

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -30,6 +30,7 @@ const schema = v.object({
 	listCategories: v.optional(v.array(v.string())),
 	doNotListBlocks: v.optional(v.array(v.string())),
 	doNotListCategories: v.optional(v.array(v.string())),
+	allowSubdirectories: v.optional(v.boolean()),
 	preview: v.optional(v.boolean()),
 	output: v.boolean(),
 	verbose: v.boolean(),
@@ -63,6 +64,7 @@ const build = new Command('build')
 		'Do not list the categories with these names.'
 	)
 	.option('--exclude-deps [deps...]', 'Dependencies that should not be added.')
+	.option('--allow-subdirectories', 'Allow subdirectories to be built.')
 	.option('--preview', 'Display a preview of the blocks list.')
 	.option('--no-output', `Do not output a \`${MANIFEST_FILE}\` file.`)
 	.option('--verbose', 'Include debug logs.', false)
@@ -98,6 +100,7 @@ const _build = async (options: Options) => {
 					includeCategories: options.includeCategories ?? [],
 					excludeBlocks: options.excludeBlocks ?? [],
 					excludeCategories: options.excludeCategories ?? [],
+					allowSubdirectories: options.allowSubdirectories,
 					preview: options.preview,
 				} satisfies RegistryConfig;
 			}
@@ -118,6 +121,8 @@ const _build = async (options: Options) => {
 			if (options.excludeBlocks) mergedVal.excludeBlocks = options.excludeBlocks;
 			if (options.excludeCategories) mergedVal.excludeCategories = options.excludeCategories;
 			if (options.excludeDeps) mergedVal.excludeDeps = options.excludeDeps;
+			if (options.allowSubdirectories !== undefined)
+				mergedVal.allowSubdirectories = options.allowSubdirectories;
 			if (options.preview !== undefined) mergedVal.preview = options.preview;
 
 			mergedVal.rules = { ...DEFAULT_CONFIG, ...mergedVal.rules };

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -265,11 +265,13 @@ const _build = async (options: Options) => {
 					const originalPath = path.join(options.cwd, block.directory);
 					const newDirPath = path.join(outDir, block.directory);
 
-					if (!fs.existsSync(newDirPath)) {
-						fs.mkdirSync(newDirPath, { recursive: true });
-					}
-
 					for (const file of block.files) {
+						const containing = path.join(newDirPath, file, '../');
+
+						if (!fs.existsSync(containing)) {
+							fs.mkdirSync(containing, { recursive: true });
+						}
+
 						fs.copyFileSync(path.join(originalPath, file), path.join(newDirPath, file));
 					}
 				}

--- a/packages/cli/src/utils/build/index.ts
+++ b/packages/cli/src/utils/build/index.ts
@@ -234,7 +234,7 @@ const buildBlocksDirectory = (blocksPath: string, { cwd, ignore, config }: Optio
 	return categories;
 };
 
-const shouldListBlock = (name: string, config: RegistryConfig) => {
+export const shouldListBlock = (name: string, config: RegistryConfig) => {
 	// the length check is just a short circuit here
 	if (config.doNotListBlocks.length > 0 && config.doNotListBlocks.includes(name)) return false;
 
@@ -247,7 +247,7 @@ const shouldListBlock = (name: string, config: RegistryConfig) => {
 	return true;
 };
 
-const shouldIncludeBlock = (name: string, config: RegistryConfig) => {
+export const shouldIncludeBlock = (name: string, config: RegistryConfig) => {
 	// the length check is just a short circuit here
 	if (config.excludeBlocks.length > 0 && config.excludeBlocks.includes(name)) return false;
 
@@ -260,7 +260,7 @@ const shouldIncludeBlock = (name: string, config: RegistryConfig) => {
 	return true;
 };
 
-const shouldListCategory = (name: string, config: RegistryConfig) => {
+export const shouldListCategory = (name: string, config: RegistryConfig) => {
 	// the length check is just a short circuit here
 	if (config.doNotListCategories.length > 0 && config.doNotListCategories.includes(name))
 		return false;
@@ -274,7 +274,7 @@ const shouldListCategory = (name: string, config: RegistryConfig) => {
 	return true;
 };
 
-const shouldIncludeCategory = (name: string, config: RegistryConfig) => {
+export const shouldIncludeCategory = (name: string, config: RegistryConfig) => {
 	// the length check is just a short circuit here
 	if (config.excludeCategories.length > 0 && config.excludeCategories.includes(name))
 		return false;

--- a/packages/cli/src/utils/build/index.ts
+++ b/packages/cli/src/utils/build/index.ts
@@ -146,7 +146,8 @@ const buildBlocksDirectory = (blocksPath: string, { cwd, ignore, config }: Optio
 				const walkFiles = (base: string, files: string[]) => {
 					for (const f of files) {
 						const filePath = path.join(base, f);
-						const relativeFilePath = path.relative(path.join(cwd, blockDir), filePath);
+						// relative to the block root
+						const relativeFilePath = filePath.slice(blockDir.length + 1);
 
 						if (isTestFile(f)) {
 							hasTests = true;

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -64,6 +64,7 @@ const registryConfigSchema = v.object({
 	listBlocks: v.optional(v.array(v.string()), []),
 	listCategories: v.optional(v.array(v.string()), []),
 	excludeDeps: v.optional(v.array(v.string()), []),
+	allowSubdirectories: v.optional(v.boolean()),
 	preview: v.optional(v.boolean()),
 	rules: v.optional(ruleConfigSchema),
 });

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -45,7 +45,7 @@ describe('build', () => {
 			dirs: ['./src', './'],
 			includeBlocks: [],
 			includeCategories: [],
-			excludeBlocks: ["subtract"],
+			excludeBlocks: [],
 			excludeCategories: ['src'],
 			doNotListBlocks: [],
 			doNotListCategories: [],
@@ -98,11 +98,6 @@ describe('build', () => {
 export const add = (a: number, b: number) => a + b;
 
 export const logAnswer = (a: number, b: number) => log(\`Answer is: \${add(a, b)}\`);`
-		);
-
-		fs.writeFileSync(
-			'./src/utils/subtract.ts',
-			'export const subtract = (a: number, b: number) => a - b;'
 		);
 
 		fs.writeFileSync(

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -6,6 +6,12 @@ import type { Category } from '../src/types';
 import type { RegistryConfig } from '../src/utils/config';
 import { parseManifest } from '../src/utils/manifest';
 import { assertFilesExist } from './utils';
+import {
+	shouldIncludeBlock,
+	shouldIncludeCategory,
+	shouldListBlock,
+	shouldListCategory,
+} from '../src/utils/build';
 
 describe('build', () => {
 	const testDir = path.join(__dirname, '../temp-test/build');
@@ -208,5 +214,95 @@ export const createPoint = (x: number, y: number): Point => { x, y };`
 		// ensure files were copied correctly
 		assertFilesExist('./registry/src/utils', 'add.ts', 'log.ts', 'math.ts');
 		assertFilesExist('./registry/src/types', 'point.ts');
+	});
+});
+
+const defaultConfig = {
+	$schema: '',
+	dirs: [],
+	doNotListBlocks: [],
+	doNotListCategories: [],
+	listBlocks: [],
+	listCategories: [],
+	excludeDeps: [],
+	includeBlocks: [],
+	includeCategories: [],
+	excludeBlocks: [],
+	excludeCategories: [],
+};
+
+describe('shouldListBlock', () => {
+	it('lists if unspecified', () => {
+		expect(shouldListBlock('a', { ...defaultConfig })).toBe(true);
+	});
+
+	it('lists when should list', () => {
+		expect(shouldListBlock('a', { ...defaultConfig, listBlocks: ['a'] })).toBe(true);
+		expect(shouldListBlock('a', { ...defaultConfig, doNotListBlocks: ['b'] })).toBe(true);
+	});
+
+	it('does not list when should not list', () => {
+		expect(shouldListBlock('a', { ...defaultConfig, listBlocks: ['b'] })).toBe(false);
+		expect(shouldListBlock('a', { ...defaultConfig, doNotListBlocks: ['a'] })).toBe(false);
+	});
+});
+
+describe('shouldListCategory', () => {
+	it('lists if unspecified', () => {
+		expect(shouldListCategory('a', { ...defaultConfig })).toBe(true);
+	});
+
+	it('lists when should list', () => {
+		expect(shouldListCategory('a', { ...defaultConfig, listCategories: ['a'] })).toBe(true);
+		expect(shouldListCategory('a', { ...defaultConfig, doNotListCategories: ['b'] })).toBe(
+			true
+		);
+	});
+
+	it('does not list when should not list', () => {
+		expect(shouldListCategory('a', { ...defaultConfig, listCategories: ['b'] })).toBe(false);
+		expect(shouldListCategory('a', { ...defaultConfig, doNotListCategories: ['a'] })).toBe(
+			false
+		);
+	});
+});
+
+describe('shouldIncludeBlock', () => {
+	it('lists if unspecified', () => {
+		expect(shouldIncludeBlock('a', { ...defaultConfig })).toBe(true);
+	});
+
+	it('lists when should list', () => {
+		expect(shouldIncludeBlock('a', { ...defaultConfig, includeBlocks: ['a'] })).toBe(true);
+		expect(shouldIncludeBlock('a', { ...defaultConfig, excludeBlocks: ['b'] })).toBe(true);
+	});
+
+	it('does not list when should not list', () => {
+		expect(shouldIncludeBlock('a', { ...defaultConfig, includeBlocks: ['b'] })).toBe(false);
+		expect(shouldIncludeBlock('a', { ...defaultConfig, excludeBlocks: ['a'] })).toBe(false);
+	});
+});
+
+describe('shouldIncludeCategory', () => {
+	it('lists if unspecified', () => {
+		expect(shouldIncludeCategory('a', { ...defaultConfig })).toBe(true);
+	});
+
+	it('lists when should list', () => {
+		expect(shouldIncludeCategory('a', { ...defaultConfig, includeCategories: ['a'] })).toBe(
+			true
+		);
+		expect(shouldIncludeCategory('a', { ...defaultConfig, excludeCategories: ['b'] })).toBe(
+			true
+		);
+	});
+
+	it('does not list when should not list', () => {
+		expect(shouldIncludeCategory('a', { ...defaultConfig, includeCategories: ['b'] })).toBe(
+			false
+		);
+		expect(shouldIncludeCategory('a', { ...defaultConfig, excludeCategories: ['a'] })).toBe(
+			false
+		);
 	});
 });

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -45,7 +45,7 @@ describe('build', () => {
 			dirs: ['./src', './'],
 			includeBlocks: [],
 			includeCategories: [],
-			excludeBlocks: [],
+			excludeBlocks: ["subtract"],
 			excludeCategories: ['src'],
 			doNotListBlocks: [],
 			doNotListCategories: [],
@@ -98,6 +98,11 @@ describe('build', () => {
 export const add = (a: number, b: number) => a + b;
 
 export const logAnswer = (a: number, b: number) => log(\`Answer is: \${add(a, b)}\`);`
+		);
+
+		fs.writeFileSync(
+			'./src/utils/subtract.ts',
+			'export const subtract = (a: number, b: number) => a - b;'
 		);
 
 		fs.writeFileSync(

--- a/packages/cli/tests/utils.ts
+++ b/packages/cli/tests/utils.ts
@@ -1,14 +1,9 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import { expect } from 'vitest';
 
 export const assertFilesExist = (dir: string, ...files: string[]) => {
-	const fileSet = new Set(files);
-
-	const filesInDir = fs.readdirSync(dir);
-
-	for (const file of filesInDir) {
-		fileSet.delete(file);
+	for (const f of files) {
+		expect(fs.existsSync(path.join(dir, f))).toBe(true);
 	}
-
-	expect(Array.from(fileSet)).toStrictEqual([]);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,11 +87,11 @@ importers:
         specifier: ^3.4.2
         version: 3.4.2
       semver:
-        specifier: ^7.7.0
-        version: 7.7.0
+        specifier: ^7.7.1
+        version: 7.7.1
       svelte:
-        specifier: ^5.19.6
-        version: 5.19.6
+        specifier: ^5.19.7
+        version: 5.19.7
       ts-morph:
         specifier: ^25.0.0
         version: 25.0.0
@@ -127,8 +127,8 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vitest:
-        specifier: ^3.0.4
-        version: 3.0.4(@types/node@22.13.0)(jiti@1.21.7)(jsdom@26.0.0)(yaml@2.7.0)
+        specifier: ^3.0.5
+        version: 3.0.5(@types/node@22.13.0)(jiti@1.21.7)(jsdom@26.0.0)(yaml@2.7.0)
 
   sites/docs:
     devDependencies:
@@ -1274,11 +1274,11 @@ packages:
     resolution: {integrity: sha512-GeCAHLzKkL2kMFqatgqyiiNh+FILOSAV8x8imBDo6AWQ91w30Kaxw4FnzUDqgcd9z8aCYOBQ7RJxBBGfyr+USQ==}
     engines: {node: '>=18.16.0'}
 
-  '@vitest/expect@3.0.4':
-    resolution: {integrity: sha512-Nm5kJmYw6P2BxhJPkO3eKKhGYKRsnqJqf+r0yOGRKpEP+bSCBDsjXgiu1/5QFrnPMEgzfC38ZEjvCFgaNBC0Eg==}
+  '@vitest/expect@3.0.5':
+    resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
 
-  '@vitest/mocker@3.0.4':
-    resolution: {integrity: sha512-gEef35vKafJlfQbnyOXZ0Gcr9IBUsMTyTLXsEQwuyYAerpHqvXhzdBnDFuHLpFqth3F7b6BaFr4qV/Cs1ULx5A==}
+  '@vitest/mocker@3.0.5':
+    resolution: {integrity: sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -1288,20 +1288,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.0.4':
-    resolution: {integrity: sha512-ts0fba+dEhK2aC9PFuZ9LTpULHpY/nd6jhAQ5IMU7Gaj7crPCTdCFfgvXxruRBLFS+MLraicCuFXxISEq8C93g==}
+  '@vitest/pretty-format@3.0.5':
+    resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
 
-  '@vitest/runner@3.0.4':
-    resolution: {integrity: sha512-dKHzTQ7n9sExAcWH/0sh1elVgwc7OJ2lMOBrAm73J7AH6Pf9T12Zh3lNE1TETZaqrWFXtLlx3NVrLRb5hCK+iw==}
+  '@vitest/runner@3.0.5':
+    resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
 
-  '@vitest/snapshot@3.0.4':
-    resolution: {integrity: sha512-+p5knMLwIk7lTQkM3NonZ9zBewzVp9EVkVpvNta0/PlFWpiqLaRcF4+33L1it3uRUCh0BGLOaXPPGEjNKfWb4w==}
+  '@vitest/snapshot@3.0.5':
+    resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
 
-  '@vitest/spy@3.0.4':
-    resolution: {integrity: sha512-sXIMF0oauYyUy2hN49VFTYodzEAu744MmGcPR3ZBsPM20G+1/cSW/n1U+3Yu/zHxX2bIDe1oJASOkml+osTU6Q==}
+  '@vitest/spy@3.0.5':
+    resolution: {integrity: sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==}
 
-  '@vitest/utils@3.0.4':
-    resolution: {integrity: sha512-8BqC1ksYsHtbWH+DfpOAKrFw3jl3Uf9J7yeFh85Pz52IWuh1hBBtyfEbRNNZNjl8H8A5yMLH9/t+k7HIKzQcZQ==}
+  '@vitest/utils@3.0.5':
+    resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -2873,13 +2873,13 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  semver@7.6.3:
-    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
+  semver@7.7.0:
+    resolution: {integrity: sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==}
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.0:
-    resolution: {integrity: sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==}
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3048,6 +3048,10 @@ packages:
 
   svelte@5.19.6:
     resolution: {integrity: sha512-6ydekB3qyqUal+UhfMjmVOjRGtxysR8vuiMhi2nwuBtPJWnctVlsGspjVFB05qmR+TXI1emuqtZt81c0XiFleA==}
+    engines: {node: '>=18'}
+
+  svelte@5.19.7:
+    resolution: {integrity: sha512-I0UUp2MpB5gF8aqHJVklOcRcoLgQNnBolSwLMMqDepE9gVwmGeYBmJp1/obzae72QpxdPIymA4AunIm2x70LBg==}
     engines: {node: '>=18'}
 
   sveltekit-superforms@2.23.1:
@@ -3351,8 +3355,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@3.0.4:
-    resolution: {integrity: sha512-7JZKEzcYV2Nx3u6rlvN8qdo3QV7Fxyt6hx+CCKz9fbWxdX5IvUOmTWEAxMrWxaiSf7CKGLJQ5rFu8prb/jBjOA==}
+  vite-node@3.0.5:
+    resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -3404,16 +3408,16 @@ packages:
       vite:
         optional: true
 
-  vitest@3.0.4:
-    resolution: {integrity: sha512-6XG8oTKy2gnJIFTHP6LD7ExFeNLxiTkK3CfMvT7IfR8IN+BYICCf0lXUQmX7i7JoxUP8QmeP4mTnWXgflu4yjw==}
+  vitest@3.0.5:
+    resolution: {integrity: sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.0.4
-      '@vitest/ui': 3.0.4
+      '@vitest/browser': 3.0.5
+      '@vitest/ui': 3.0.5
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -4708,43 +4712,43 @@ snapshots:
       validator: 13.12.0
     optional: true
 
-  '@vitest/expect@3.0.4':
+  '@vitest/expect@3.0.5':
     dependencies:
-      '@vitest/spy': 3.0.4
-      '@vitest/utils': 3.0.4
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
       chai: 5.1.2
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.4(vite@6.0.11(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.5(vite@6.0.11(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 3.0.4
+      '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.0.11(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0)
 
-  '@vitest/pretty-format@3.0.4':
+  '@vitest/pretty-format@3.0.5':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.0.4':
+  '@vitest/runner@3.0.5':
     dependencies:
-      '@vitest/utils': 3.0.4
+      '@vitest/utils': 3.0.5
       pathe: 2.0.2
 
-  '@vitest/snapshot@3.0.4':
+  '@vitest/snapshot@3.0.5':
     dependencies:
-      '@vitest/pretty-format': 3.0.4
+      '@vitest/pretty-format': 3.0.5
       magic-string: 0.30.17
       pathe: 2.0.2
 
-  '@vitest/spy@3.0.4':
+  '@vitest/spy@3.0.5':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@3.0.4':
+  '@vitest/utils@3.0.5':
     dependencies:
-      '@vitest/pretty-format': 3.0.4
+      '@vitest/pretty-format': 3.0.5
       loupe: 3.1.2
       tinyrainbow: 2.0.0
 
@@ -5074,7 +5078,7 @@ snapshots:
       dot-prop: 9.0.0
       env-paths: 3.0.0
       json-schema-typed: 8.0.1
-      semver: 7.7.0
+      semver: 7.7.1
       uint8array-extras: 1.4.0
 
   confbox@0.1.8: {}
@@ -5234,7 +5238,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@9.19.0(jiti@1.21.7)):
     dependencies:
       eslint: 9.19.0(jiti@1.21.7)
-      semver: 7.6.3
+      semver: 7.7.0
 
   eslint-config-prettier@10.0.1(eslint@9.19.0(jiti@1.21.7)):
     dependencies:
@@ -5252,7 +5256,7 @@ snapshots:
       postcss-load-config: 3.1.4(postcss@8.5.1)
       postcss-safe-parser: 6.0.0(postcss@8.5.1)
       postcss-selector-parser: 6.1.2
-      semver: 7.6.3
+      semver: 7.7.0
       svelte-eslint-parser: 0.43.0(svelte@5.19.6)
     optionalDependencies:
       svelte: 5.19.6
@@ -6351,9 +6355,9 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  semver@7.6.3: {}
-
   semver@7.7.0: {}
+
+  semver@7.7.1: {}
 
   set-cookie-parser@2.7.1: {}
 
@@ -6522,6 +6526,23 @@ snapshots:
       svelte: 5.19.6
 
   svelte@5.19.6:
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@types/estree': 1.0.6
+      acorn: 8.14.0
+      acorn-typescript: 1.4.13(acorn@8.14.0)
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      esm-env: 1.2.2
+      esrap: 1.4.3
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.17
+      zimmerframe: 1.1.2
+
+  svelte@5.19.7:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -6848,7 +6869,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.0.4(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0):
+  vite-node@3.0.5(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
@@ -6884,15 +6905,15 @@ snapshots:
     optionalDependencies:
       vite: 6.0.11(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0)
 
-  vitest@3.0.4(@types/node@22.13.0)(jiti@1.21.7)(jsdom@26.0.0)(yaml@2.7.0):
+  vitest@3.0.5(@types/node@22.13.0)(jiti@1.21.7)(jsdom@26.0.0)(yaml@2.7.0):
     dependencies:
-      '@vitest/expect': 3.0.4
-      '@vitest/mocker': 3.0.4(vite@6.0.11(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0))
-      '@vitest/pretty-format': 3.0.4
-      '@vitest/runner': 3.0.4
-      '@vitest/snapshot': 3.0.4
-      '@vitest/spy': 3.0.4
-      '@vitest/utils': 3.0.4
+      '@vitest/expect': 3.0.5
+      '@vitest/mocker': 3.0.5(vite@6.0.11(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0))
+      '@vitest/pretty-format': 3.0.5
+      '@vitest/runner': 3.0.5
+      '@vitest/snapshot': 3.0.5
+      '@vitest/spy': 3.0.5
+      '@vitest/utils': 3.0.5
       chai: 5.1.2
       debug: 4.4.0
       expect-type: 1.1.0
@@ -6904,7 +6925,7 @@ snapshots:
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
       vite: 6.0.11(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0)
-      vite-node: 3.0.4(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0)
+      vite-node: 3.0.5(@types/node@22.13.0)(jiti@1.21.7)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.0

--- a/sites/docs/src/routes/docs/cli/build/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/build/+page.svelte
@@ -136,19 +136,27 @@
 <OptionDocs name="--exclude-deps">
 	{#snippet description()}
 		Prevent these dependencies from being included in the <CodeSpan>jsrepo-manifest.json</CodeSpan> file.
-		Corresponding config key: <Link href="/docs/jsrepo-build-config-json#excludeDeps"
-			>excludeDeps</Link
-		>
+		Corresponding config key: <Link href="/docs/jsrepo-build-config-json#excludeDeps">
+			excludeDeps
+		</Link>
 	{/snippet}
 	{#snippet usage()}
 		<Snippet command="execute" args={['jsrepo', 'build', '--exclude-deps', 'svelte', 'react']} />
 	{/snippet}
 </OptionDocs>
+<OptionDocs name="--allow-subdirectories">
+	{#snippet description()}
+		Allow subdirectories to be built. Corresponding config key:
+		<Link href="/docs/jsrepo-build-config-json#allowSubdirectories">allowSubdirectories</Link>
+	{/snippet}
+	{#snippet usage()}
+		<Snippet command="execute" args={['jsrepo', 'build', '--allow-subdirectories']} />
+	{/snippet}
+</OptionDocs>
 <OptionDocs name="--preview">
 	{#snippet description()}
-		Display a preview of the blocks list. Corresponding config key: <Link
-			href="/docs/jsrepo-build-config-json#preview">preview</Link
-		>
+		Display a preview of the blocks list. Corresponding config key:
+		<Link href="/docs/jsrepo-build-config-json#preview">preview</Link>
 	{/snippet}
 	{#snippet usage()}
 		<Snippet command="execute" args={['jsrepo', 'build', '--preview']} />

--- a/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
+++ b/sites/docs/src/routes/docs/jsrepo-build-config-json/+page.svelte
@@ -222,6 +222,16 @@
     ]
 }`}
 />
+<SubHeading>allowSubdirectories</SubHeading>
+<p>
+	<CodeSpan>allowSubdirectories</CodeSpan> allows subdirectories to be built.
+</p>
+<Code
+	lang="json"
+	code={`{
+    "allowSubdirectories": false
+}`}
+/>
 <SubHeading>preview</SubHeading>
 <p>
 	<CodeSpan>preview</CodeSpan> displays a preview of the blocks list.

--- a/sites/docs/static/docs/cli/llms.txt
+++ b/sites/docs/static/docs/cli/llms.txt
@@ -2,7 +2,7 @@
 
 > A CLI to add shared code from remote repositories.
  
-Latest Version: 1.29.1
+Latest Version: 1.30.1
 
 ## Commands
 
@@ -57,6 +57,7 @@ jsrepo build [options]
 - --do-not-list-blocks [blockNames...]: Do not list the blocks with these names. 
 - --do-not-list-categories [categoryNames...]: Do not list the categories with these names. 
 - --exclude-deps [deps...]: Dependencies that should not be added. 
+- --allow-subdirectories: Allow subdirectories to be built. 
 - --preview: Display a preview of the blocks list. 
 - --no-output: Do not output a `jsrepo-manifest.json` file. 
 - --verbose: Include debug logs. 


### PR DESCRIPTION
Fixes #399 

Adds an `allowSubdirectories` config key that enables building blocks that contain subdirectories.

This allows for structures like:
```ts
root
├── ...
└── <category>
    └── <block>
        ├── <folder>
		│	└── <file>
        └── <file>
```

- Bump dependencies
- Update local dependency resolution
	- Had to do this since before there wasn't any way to tell if an import was self referencing but now we know
- Slightly refactor build
- Update build tests