### PR TITLE
fix(docs): Use `text-foreground` instead of `text-primary` in light mode

### DIFF
--- a/sites/docs/src/lib/components/site/docs/jsrepo.svelte
+++ b/sites/docs/src/lib/components/site/docs/jsrepo.svelte
@@ -1,1 +1,1 @@
-<span class="text-primary font-mono"> jsrepo </span>
+<span class="text-foreground dark:text-primary font-mono"> jsrepo </span>

--- a/sites/docs/src/lib/components/site/docs/link.svelte
+++ b/sites/docs/src/lib/components/site/docs/link.svelte
@@ -11,6 +11,11 @@
 	let { href, class: className, children, target = '_self', ...rest }: Props = $props();
 </script>
 
-<a {...rest} {href} {target} class={cn('text-primary hover:underline', className)}>
+<a
+	{...rest}
+	{href}
+	{target}
+	class={cn('text-foreground dark:text-primary hover:underline', className)}
+>
 	{@render children?.()}
 </a>

--- a/sites/docs/src/lib/components/site/header.svelte
+++ b/sites/docs/src/lib/components/site/header.svelte
@@ -37,7 +37,7 @@
 				<nav class="place-items-center gap-4 flex">
 					<a
 						href="/"
-						class="hover:text-primary text-muted-foreground transition-all data-[active=true]:text-primary"
+						class="hover:dark:text-primary hover:text-foreground text-muted-foreground transition-all data-[active=true]:text-foreground data-[active=true]:dark:text-primary"
 						use:active={{
 							activeForSubdirectories: false
 						}}
@@ -46,7 +46,7 @@
 					</a>
 					<a
 						href="/docs"
-						class="hover:text-primary text-muted-foreground transition-all data-[active=true]:text-primary"
+						class="hover:dark:text-primary hover:text-foreground text-muted-foreground transition-all data-[active=true]:text-foreground data-[active=true]:dark:text-primary"
 						use:active={{
 							activeForSubdirectories: true
 						}}
@@ -55,7 +55,7 @@
 					</a>
 					<a
 						href="/demos"
-						class="hover:text-primary text-muted-foreground transition-all data-[active=true]:text-primary"
+						class="hover:dark:text-primary hover:text-foreground text-muted-foreground transition-all data-[active=true]:text-foreground data-[active=true]:dark:text-primary"
 						use:active={{
 							activeForSubdirectories: true
 						}}

--- a/sites/docs/src/lib/components/ui/snippet/jsrepo-snippet.svelte
+++ b/sites/docs/src/lib/components/ui/snippet/jsrepo-snippet.svelte
@@ -19,7 +19,7 @@
 	)}
 >
 	<div class="text-nowrap max-w-full overflow-x-auto scrollbar-hide">
-		<span class="text-primary">jsrepo</span>
+		<span class="text-foreground dark:text-primary">jsrepo</span>
 		<span>{args.join(' ')}</span>
 	</div>
 	<SimpleCopyButton {text} class="absolute top-1/2 -translate-y-1/2 right-2" />

--- a/sites/docs/src/lib/components/ui/snippet/snippet.svelte
+++ b/sites/docs/src/lib/components/ui/snippet/snippet.svelte
@@ -27,7 +27,7 @@
 	)}
 >
 	<div class="text-nowrap max-w-full overflow-x-auto scrollbar-hide">
-		<span class="text-primary">{cmd?.command}</span>
+		<span class="text-foreground dark:text-primary">{cmd?.command}</span>
 		<span>{cmd?.args.join(' ')}</span>
 	</div>
 	<CopyButton bind:pm={$pm} {text} class="absolute top-1/2 -translate-y-1/2 right-2" />

--- a/sites/docs/src/routes/docs/+layout.svelte
+++ b/sites/docs/src/routes/docs/+layout.svelte
@@ -141,7 +141,7 @@
 				{#each pageHeadings as heading}
 					<a
 						href="#{heading.el.innerText}"
-						class="text-muted-foreground text-sm hover:text-primary transition-all data-[active=true]:text-primary"
+						class="text-muted-foreground text-sm hover:text-foreground hover:dark:text-primary transition-all data-[active=true]:text-foreground data-[active=true]:dark:text-primary"
 						data-active={activeHeading === heading.el.innerText}
 					>
 						{heading.el.innerText}


### PR DESCRIPTION
Fixes #398 

For all you light mode psychopaths... (JK)