### PR TITLE
feat(cli): ux improvements

### DIFF
--- a/.changeset/cuddly-comics-hammer.md
+++ b/.changeset/cuddly-comics-hammer.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+feat: Autofix incorrect extension on (.ts|js|mjs|cjs) config files.

--- a/.changeset/famous-hotels-film.md
+++ b/.changeset/famous-hotels-film.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+fix: Ensure registries coming from args are always configured first.

--- a/.changeset/great-bobcats-hunt.md
+++ b/.changeset/great-bobcats-hunt.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+feat: Improve error messages when paths are incorrectly named or do not resolve.

--- a/.changeset/many-geese-thank.md
+++ b/.changeset/many-geese-thank.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+fix: Do not accept invalid path default blocks path on init.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": {
 		".": {
@@ -34,10 +25,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -150,7 +150,8 @@ const _initProject = async (registries: string[], options: Options) => {
 			if (value.trim() === '') return 'Please provide a value';
 		},
 		placeholder: './src/blocks',
-		initialValue: initialConfig.isOk() ? initialConfig.unwrap().paths['*'] : undefined,
+		defaultValue: './src/blocks',
+		initialValue: initialConfig.isOk() ? initialConfig.unwrap().paths['*'] : './src/blocks',
 	});
 
 	if (isCancel(defaultPathResult)) {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -152,14 +152,20 @@ const _initProject = async (registries: string[], options: Options) => {
 		validate(value) {
 			if (value.trim() === '') return 'Please provide a value';
 
-			if (!value.startsWith('./') && tsconfigResult !== null) {
+			if (!value.startsWith('./')) {
+				const error =
+					'Invalid path alias! If you are intending to use a relative path make sure it starts with `./`';
+
+				if (tsconfigResult === null) {
+					return error;
+				}
+
 				const matcher = createPathsMatcher(tsconfigResult);
 
 				if (matcher) {
 					const found = matcher(value);
 
-					if (found.length === 0)
-						return 'Invalid path alias! If you are intending to use a relative path make sure it starts with `./`';
+					if (found.length === 0) return error;
 				}
 			}
 		},

--- a/packages/cli/src/utils/blocks/ts/strings.ts
+++ b/packages/cli/src/utils/blocks/ts/strings.ts
@@ -2,15 +2,15 @@
  *
  * ## Usage
  * ```ts
- * startsWithOneOf('a', 'a', 'b'); // true
- * startsWithOneOf('c', 'a', 'b'); // false
+ * startsWithOneOf('ab', 'a', 'c'); // true
+ * startsWithOneOf('cc', 'a', 'b'); // false
  * ```
  *
  * @param str
  * @param strings
  * @returns
  */
-const startsWithOneOf = (str: string, strings: string[]): boolean => {
+export const startsWithOneOf = (str: string, strings: string[]): boolean => {
 	for (const s of strings) {
 		if (str.startsWith(s)) return true;
 	}
@@ -18,4 +18,22 @@ const startsWithOneOf = (str: string, strings: string[]): boolean => {
 	return false;
 };
 
-export { startsWithOneOf };
+/** Returns true if `str` starts with one of the provided `strings`.
+ *
+ * ## Usage
+ * ```ts
+ * endsWithOneOf('cb', 'a', 'b'); // true
+ * endsWithOneOf('cc', 'a', 'b'); // false
+ * ```
+ *
+ * @param str
+ * @param strings
+ * @returns
+ */
+export const endsWithOneOf = (str: string, strings: string[]): boolean => {
+	for (const s of strings) {
+		if (str.endsWith(s)) return true;
+	}
+
+	return false;
+};

--- a/packages/cli/src/utils/files.ts
+++ b/packages/cli/src/utils/files.ts
@@ -1,8 +1,11 @@
+import fs from 'node:fs';
 import type { PartialConfiguration } from '@biomejs/wasm-nodejs';
 import color from 'chalk';
 import escapeStringRegexp from 'escape-string-regexp';
+import path from 'pathe';
 import type * as prettier from 'prettier';
 import { Err, Ok, type Result } from './blocks/ts/result';
+import { endsWithOneOf } from './blocks/ts/strings';
 import type { ProjectConfig } from './config';
 import { resolveLocalDependencyTemplate } from './dependencies';
 import { languages } from './language-support';
@@ -28,7 +31,7 @@ type TransformRemoteContentOptions = {
  * @param param0
  * @returns
  */
-const transformRemoteContent = async ({
+export const transformRemoteContent = async ({
 	file,
 	config,
 	imports,
@@ -98,7 +101,7 @@ type FormatOptions = {
  * @param param0
  * @returns
  */
-const formatFile = async ({
+export const formatFile = async ({
 	file,
 	config,
 	prettierOptions,
@@ -124,4 +127,22 @@ const formatFile = async ({
 	return newContent;
 };
 
-export { transformRemoteContent, formatFile };
+export const matchJSDescendant = (searchFilePath: string): string | undefined => {
+	const MATCH_EXTENSIONS = ['.js', '.ts', '.cjs', '.mjs'];
+
+	if (!endsWithOneOf(searchFilePath, MATCH_EXTENSIONS)) return undefined;
+
+	const dir = path.dirname(searchFilePath);
+
+	const files = fs.readdirSync(dir);
+
+	const parsedSearch = path.parse(searchFilePath);
+
+	for (const file of files) {
+		if (!endsWithOneOf(file, MATCH_EXTENSIONS)) continue;
+
+		if (path.parse(file).name === parsedSearch.name) return path.join(dir, file);
+	}
+
+	return undefined;
+};

--- a/sites/docs/jsrepo.json
+++ b/sites/docs/jsrepo.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://unpkg.com/jsrepo@1.18.0/schemas/project-config.json",
+	"$schema": "https://unpkg.com/jsrepo@1.33.0/schemas/project-config.json",
 	"repos": ["github/ieedan/std", "github/ieedan/shadcn-svelte-extras"],
 	"includeTests": false,
 	"watermark": true,


### PR DESCRIPTION
Fixes #420 
Fixes #421 

- Improves error messages when path aliases are incorrect
- Prevent inputting invalid path for default blocks path on `init`
- Autofix incorrect file extensions on config files that are js descendents

+ a little code cleanup 