### PR TITLE
feat: Include remote dependencies for config files 🎉

### DIFF
--- a/.changeset/tricky-humans-fold.md
+++ b/.changeset/tricky-humans-fold.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+feat: Resolve remote dependencies for config files 🎉

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": {
 		".": {
@@ -34,10 +25,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/schemas/project-config.json
+++ b/packages/cli/schemas/project-config.json
@@ -32,7 +32,7 @@
 			}
 		},
 		"paths": {
-			"description": "Paths used to map categories to a directory.",
+			"description": "Paths used to map categories to a directory. TypeScript path aliases are allowed, any relative paths must start with `./`",
 			"type": "object",
 			"required": ["*"],
 			"properties": {

--- a/packages/cli/schemas/registry-config.json
+++ b/packages/cli/schemas/registry-config.json
@@ -213,6 +213,18 @@
 					"type": "string",
 					"enum": ["error", "warn", "off"],
 					"default": "error"
+				},
+				"no-config-file-framework-dependency": {
+					"description": "Disallow frameworks (Svelte, Vue, React, etc.) as dependencies of config files.",
+					"type": "string",
+					"enum": ["error", "warn", "off"],
+					"default": "warn"
+				},
+				"no-config-file-unpinned-dependency": {
+					"description": "Require all dependencies of config files to have a pinned version.",
+					"type": "string",
+					"enum": ["error", "warn", "off"],
+					"default": "warn"
 				}
 			},
 			"default": {
@@ -223,7 +235,9 @@
 				"no-circular-dependency": "error",
 				"no-unused-block": "warn",
 				"no-framework-dependency": "warn",
-				"require-config-file-exists": "error"
+				"require-config-file-exists": "error",
+				"no-config-file-framework-dependency": "warn",
+				"no-config-file-unpinned-dependency": "warn"
 			}
 		}
 	},

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -9,7 +9,7 @@ import { context } from '../cli';
 import { MANIFEST_FILE } from '../constants';
 import type { Category, Manifest } from '../types';
 import * as ascii from '../utils/ascii';
-import { buildBlocksDirectory, pruneUnused } from '../utils/build';
+import { buildBlocksDirectory, buildConfigFiles, pruneUnused } from '../utils/build';
 import { DEFAULT_CONFIG, runRules } from '../utils/build/check';
 import { type RegistryConfig, getRegistryConfig } from '../utils/config';
 import { parseManifest } from '../utils/manifest';
@@ -203,7 +203,9 @@ const _build = async (options: Options) => {
 		loading.stop(`Built ${color.cyan(dirPath)}`);
 	}
 
-	const manifest = createManifest(categories, config);
+	const configFiles = buildConfigFiles(config, { cwd: options.cwd });
+
+	const manifest = createManifest(categories, configFiles, config);
 
 	loading.start('Checking manifest');
 
@@ -303,10 +305,14 @@ const _build = async (options: Options) => {
 	}
 };
 
-export const createManifest = (categories: Category[], config: RegistryConfig) => {
+export const createManifest = (
+	categories: Category[],
+	configFiles: Manifest['configFiles'],
+	config: RegistryConfig
+) => {
 	const manifest: Manifest = {
 		meta: config.meta,
-		configFiles: config.configFiles,
+		configFiles,
 		categories,
 	};
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -36,9 +36,17 @@ export const configFileSchema = v.object({
 	optional: v.optional(v.boolean(), false),
 });
 
+export type ConfigFile = v.InferOutput<typeof configFileSchema>;
+
+export const manifestConfigFileSchema = v.object({
+	...configFileSchema.entries,
+	dependencies: v.optional(v.array(v.string())),
+	devDependencies: v.optional(v.array(v.string())),
+});
+
 export const manifestSchema = v.object({
 	meta: v.optional(manifestMeta),
-	configFiles: v.optional(v.array(configFileSchema)),
+	configFiles: v.optional(v.array(manifestConfigFileSchema)),
 	categories: v.array(categorySchema),
 });
 

--- a/packages/cli/tests/build.test.ts
+++ b/packages/cli/tests/build.test.ts
@@ -112,7 +112,7 @@ describe('build', () => {
 		fs.writeFileSync('./.ignored/a.ts', '');
 
 		fs.writeFileSync('./app.css', '');
-		fs.writeFileSync('./src/hooks.ts', '');
+		fs.writeFileSync('./src/hooks.ts', 'import { x } from "lodash"');
 
 		fs.mkdirSync('./src/types', { recursive: true });
 
@@ -224,11 +224,15 @@ export const highlighter = createHighlighterCore({
 					name: 'Global CSS File',
 					path: './app.css',
 					optional: false,
+					dependencies: [],
+					devDependencies: [],
 				},
 				{
 					name: 'Hooks',
 					path: './src/hooks.ts',
 					optional: true,
+					dependencies: ['lodash'],
+					devDependencies: [],
 				},
 			],
 			categories: [


### PR DESCRIPTION
Fixes #424 

With this PR config files can now have remote dependencies which is really nice if you are using custom plugins in your config files, the dependencies will be installed on init.



