### PR TITLE
feat: Add `additional instructions` prompt to `✨ Update with AI ✨`

### DIFF
--- a/.changeset/curvy-ducks-draw.md
+++ b/.changeset/curvy-ducks-draw.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+feat: Add `additional instructions` prompt to `✨ Update with AI ✨` to allow users to give more context to the model on how to update the file

--- a/.changeset/four-doors-matter.md
+++ b/.changeset/four-doors-matter.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+feat: Add `iterate` option for `✨ Update with AI ✨` so that you can reprompt with the context of past chats and iterate on the generated file.

--- a/.changeset/thin-fireants-clean.md
+++ b/.changeset/thin-fireants-clean.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": patch
+---
+
+feat: Remember model choice for `✨ Update with AI ✨`

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -78,7 +78,7 @@ const init = new Command('init')
 		'The name of the build script. (For Registry setup)',
 		'build:registry'
 	)
-	.option('-E, --expand', 'Expands the diff so you see everything.', false)
+	.option('-E, --expand', 'Expands the diff so you see the entire file.', false)
 	.option(
 		'--max-unchanged <number>',
 		'Maximum unchanged lines that will show without being collapsed.',

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -41,7 +41,7 @@ const update = new Command('update')
 	.description('Update blocks to the code in the remote repository.')
 	.argument('[blocks...]', 'Names of the blocks you want to update. ex: (utils/math)')
 	.option('--all', 'Update all installed components.', false)
-	.option('-E, --expand', 'Expands the diff so you see everything.', false)
+	.option('-E, --expand', 'Expands the diff so you see the entire file.', false)
 	.option(
 		'--max-unchanged <number>',
 		'Maximum unchanged lines that will show without being collapsed.',

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -383,6 +383,7 @@ const _update = async (blockNames: string[], options: Options) => {
 
 								const additionalInstructions = await text({
 									message: 'Any additional instructions?',
+									defaultValue: 'None',
 								});
 
 								if (isCancel(additionalInstructions)) {
@@ -404,7 +405,7 @@ const _update = async (blockNames: string[], options: Options) => {
 											path: from,
 										},
 										additionalInstructions:
-											additionalInstructions.trim().length > 0
+											additionalInstructions !== 'None'
 												? additionalInstructions
 												: undefined,
 										loading,

--- a/packages/cli/src/utils/ai.ts
+++ b/packages/cli/src/utils/ai.ts
@@ -10,14 +10,26 @@ type File = {
 	content: string;
 };
 
+export type Message = {
+	role: 'assistant' | 'user';
+	content: string;
+};
+
+export type UpdateFileResult = {
+	content: string;
+	/** Prompt constructed by the user (for context) */
+	prompt: string;
+};
+
 export interface Model {
 	updateFile: (opts: {
 		originalFile: File;
 		newFile: File;
 		loading: ReturnType<typeof spinner>;
 		additionalInstructions?: string;
+		messages?: Message[];
 		verbose?: (msg: string) => void;
-	}) => Promise<string>;
+	}) => Promise<UpdateFileResult>;
 }
 
 export type ModelName = 'Claude 3.5 Sonnet' | 'ChatGPT 4o-mini' | 'ChatGPT 4o' | 'Phi4';
@@ -29,12 +41,24 @@ type Prompt = {
 
 const models: Record<ModelName, Model> = {
 	'Claude 3.5 Sonnet': {
-		updateFile: async ({ originalFile, newFile, loading, verbose, additionalInstructions }) => {
+		updateFile: async ({
+			originalFile,
+			newFile,
+			loading,
+			verbose,
+			additionalInstructions,
+			messages,
+		}) => {
 			const apiKey = await getApiKey('Anthropic');
 
 			if (!verbose) loading.start(`Asking ${'Claude 3.5 Sonnet'}`);
 
-			const prompt = createUpdatePrompt({ originalFile, newFile, additionalInstructions });
+			const prompt = createUpdatePrompt({
+				originalFile,
+				newFile,
+				additionalInstructions,
+				rePrompt: messages !== undefined && messages.length > 0,
+			});
 
 			verbose?.(
 				`Prompting ${'Claude 3.5 Sonnet'} with:\n${JSON.stringify(prompt, null, '\t')}`
@@ -44,23 +68,36 @@ const models: Record<ModelName, Model> = {
 				model: 'claude-3-5-sonnet-latest',
 				prompt,
 				apiKey,
+				messages,
 				maxTokens: (originalFile.content.length + newFile.content.length) * 2,
 			});
 
 			if (!verbose) loading.stop(`${'Claude 3.5 Sonnet'} updated the file`);
 
-			if (!text) return newFile.content;
+			if (!text) return { content: newFile.content, prompt: prompt.message };
 
-			return unwrapCodeFromQuotes(text);
+			return { content: unwrapCodeFromQuotes(text), prompt: prompt.message };
 		},
 	},
 	'ChatGPT 4o': {
-		updateFile: async ({ originalFile, newFile, loading, verbose, additionalInstructions }) => {
+		updateFile: async ({
+			originalFile,
+			newFile,
+			loading,
+			verbose,
+			additionalInstructions,
+			messages,
+		}) => {
 			const apiKey = await getApiKey('OpenAI');
 
 			if (!verbose) loading.start(`Asking ${'ChatGPT 4o'}`);
 
-			const prompt = createUpdatePrompt({ originalFile, newFile, additionalInstructions });
+			const prompt = createUpdatePrompt({
+				originalFile,
+				newFile,
+				additionalInstructions,
+				rePrompt: messages !== undefined && messages.length > 0,
+			});
 
 			verbose?.(`Prompting ${'ChatGPT 4o'} with:\n${JSON.stringify(prompt, null, '\t')}`);
 
@@ -68,23 +105,36 @@ const models: Record<ModelName, Model> = {
 				model: 'gpt-4o',
 				prompt,
 				apiKey,
+				messages,
 				maxTokens: (originalFile.content.length + newFile.content.length) * 2,
 			});
 
 			if (!verbose) loading.stop(`${'ChatGPT 4o'} updated the file`);
 
-			if (!text) return newFile.content;
+			if (!text) return { content: newFile.content, prompt: prompt.message };
 
-			return unwrapCodeFromQuotes(text);
+			return { content: unwrapCodeFromQuotes(text), prompt: prompt.message };
 		},
 	},
 	'ChatGPT 4o-mini': {
-		updateFile: async ({ originalFile, newFile, loading, verbose, additionalInstructions }) => {
+		updateFile: async ({
+			originalFile,
+			newFile,
+			loading,
+			verbose,
+			additionalInstructions,
+			messages,
+		}) => {
 			const apiKey = await getApiKey('OpenAI');
 
 			if (!verbose) loading.start(`Asking ${'ChatGPT 4o-mini'}`);
 
-			const prompt = createUpdatePrompt({ originalFile, newFile, additionalInstructions });
+			const prompt = createUpdatePrompt({
+				originalFile,
+				newFile,
+				additionalInstructions,
+				rePrompt: messages !== undefined && messages.length > 0,
+			});
 
 			verbose?.(`Prompting ${'ChatGPT 4o'} with:\n${JSON.stringify(prompt, null, '\t')}`);
 
@@ -92,31 +142,44 @@ const models: Record<ModelName, Model> = {
 				model: 'gpt-4o-mini',
 				prompt,
 				apiKey,
+				messages,
 				maxTokens: (originalFile.content.length + newFile.content.length) * 2,
 			});
 
 			if (!verbose) loading.stop(`${'ChatGPT 4o-mini'} updated the file`);
 
-			if (!text) return newFile.content;
+			if (!text) return { content: newFile.content, prompt: prompt.message };
 
-			return unwrapCodeFromQuotes(text);
+			return { content: unwrapCodeFromQuotes(text), prompt: prompt.message };
 		},
 	},
 	Phi4: {
-		updateFile: async ({ originalFile, newFile, loading, verbose, additionalInstructions }) => {
+		updateFile: async ({
+			originalFile,
+			newFile,
+			loading,
+			verbose,
+			additionalInstructions,
+			messages,
+		}) => {
 			if (!verbose) loading.start(`Asking ${'Phi4'}`);
 
-			const prompt = createUpdatePrompt({ originalFile, newFile, additionalInstructions });
+			const prompt = createUpdatePrompt({
+				originalFile,
+				newFile,
+				additionalInstructions,
+				rePrompt: messages !== undefined && messages.length > 0,
+			});
 
 			verbose?.(`Prompting ${'Phi4'} with:\n${JSON.stringify(prompt, null, '\t')}`);
 
-			const text = await getNextCompletionOllama({ model: 'phi4', prompt });
+			const text = await getNextCompletionOllama({ model: 'phi4', prompt, messages });
 
 			if (!verbose) loading.stop(`${'Phi4'} updated the file`);
 
-			if (!text) return newFile.content;
+			if (!text) return { content: newFile.content, prompt: prompt.message };
 
-			return unwrapCodeFromQuotes(text);
+			return { content: unwrapCodeFromQuotes(text), prompt: prompt.message };
 		},
 	},
 };
@@ -126,8 +189,10 @@ const getNextCompletionOpenAI = async ({
 	maxTokens,
 	model,
 	apiKey,
+	messages,
 }: {
 	prompt: Prompt;
+	messages?: Message[];
 	maxTokens: number;
 	model: OpenAI.Chat.ChatModel;
 	apiKey: string;
@@ -142,6 +207,7 @@ const getNextCompletionOpenAI = async ({
 				role: 'system',
 				content: prompt.system,
 			},
+			...(messages ?? []),
 			{
 				role: 'user',
 				content: prompt.message,
@@ -158,33 +224,49 @@ const getNextCompletionOpenAI = async ({
 
 const getNextCompletionAnthropic = async ({
 	prompt,
+	messages,
 	maxTokens,
 	model,
 	apiKey,
 }: {
 	prompt: Prompt;
+	messages?: Message[];
 	maxTokens: number;
 	model: Anthropic.Messages.Model;
 	apiKey: string;
 }): Promise<string | null> => {
 	const anthropic = new Anthropic({ apiKey });
 
+	// didn't want to do it this way but I couldn't get `.map` to work
+	const history: Anthropic.Messages.MessageParam[] = [];
+
+	// add history
+	if (messages) {
+		for (const message of messages) {
+			history.push({
+				role: message.role,
+				content: [{ type: 'text', text: message.content }],
+			});
+		}
+	}
+
+	// add new message
+	history.push({
+		role: 'user',
+		content: [
+			{
+				type: 'text',
+				text: prompt.message,
+			},
+		],
+	});
+
 	const msg = await anthropic.messages.create({
 		model,
 		max_tokens: Math.min(maxTokens, 8192),
 		temperature: 0.5,
 		system: prompt.system,
-		messages: [
-			{
-				role: 'user',
-				content: [
-					{
-						type: 'text',
-						text: prompt.message,
-					},
-				],
-			},
-		],
+		messages: history,
 	});
 
 	const first = msg.content[0];
@@ -197,9 +279,11 @@ const getNextCompletionAnthropic = async ({
 
 const getNextCompletionOllama = async ({
 	prompt,
+	messages,
 	model,
 }: {
 	prompt: Prompt;
+	messages?: Message[];
 	model: string;
 }): Promise<string | null> => {
 	const resp = await ollama.chat({
@@ -209,6 +293,7 @@ const getNextCompletionOllama = async ({
 				role: 'system',
 				content: prompt.system,
 			},
+			...(messages ?? []),
 			{
 				role: 'user',
 				content: prompt.message,
@@ -223,14 +308,18 @@ const createUpdatePrompt = ({
 	originalFile,
 	newFile,
 	additionalInstructions,
+	rePrompt,
 }: {
 	originalFile: File;
 	newFile: File;
 	additionalInstructions?: string;
+	rePrompt: boolean;
 }): Prompt => {
 	return {
 		system: 'You will merge two files provided by the user. You will respond only with the resulting code. DO NOT format the code with markdown, DO NOT put the code inside of triple quotes, only return the code as a raw string. DO NOT make unnecessary changes.',
-		message: `
+		message: rePrompt
+			? (additionalInstructions ?? '')
+			: `
 This is my current file ${originalFile.path}:
 <code>
 ${originalFile.content}

--- a/packages/cli/src/utils/files.ts
+++ b/packages/cli/src/utils/files.ts
@@ -92,7 +92,7 @@ type FormatOptions = {
 		/** The dest path of the file used to determine the language */
 		destPath: string;
 	};
-	config: ProjectConfig;
+	formatter: ProjectConfig['formatter'];
 	prettierOptions: prettier.Options | null;
 	biomeOptions: PartialConfiguration | null;
 };
@@ -104,7 +104,7 @@ type FormatOptions = {
  */
 export const formatFile = async ({
 	file,
-	config,
+	formatter,
 	prettierOptions,
 	biomeOptions,
 }: FormatOptions): Promise<string> => {
@@ -116,7 +116,7 @@ export const formatFile = async ({
 		try {
 			newContent = await lang.format(file.content, {
 				filePath: file.destPath,
-				formatter: config.formatter,
+				formatter,
 				prettierOptions,
 				biomeOptions,
 			});

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -320,7 +320,7 @@ export const promptUpdateFile = async ({
 					model = modelResult as ModelName;
 
 					const additionalInstructions = await text({
-						message: 'Any additional instructions?',
+						message: 'Additional instructions:',
 						defaultValue: 'None',
 						validate: (val) => {
 							// don't care if no messages have been sent

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -1,12 +1,19 @@
-import { intro, spinner } from '@clack/prompts';
+import type { PartialConfiguration } from '@biomejs/wasm-nodejs';
+import { cancel, intro, isCancel, log, select, spinner, text } from '@clack/prompts';
 import boxen from 'boxen';
 import color from 'chalk';
 import { detectSync, resolveCommand } from 'package-manager-detector';
+import type * as prettier from 'prettier';
 import semver from 'semver';
 import * as ascii from './ascii';
 import { stripAsni } from './blocks/ts/strip-ansi';
 import { packageJson } from './context';
 import { getLatestVersion } from './get-latest-version';
+import { diffLines } from 'diff';
+import { formatDiff } from './diff';
+import { type ModelName, models } from './ai';
+import { formatFile } from './files';
+import type { ProjectConfig } from './config';
 
 export type Task = {
 	loadingMessage: string;
@@ -160,6 +167,208 @@ const _intro = async () => {
 	intro(
 		`${color.bgHex('#f7df1e').black(` ${packageJson.name} `)}${color.gray(` v${packageJson.version} `)}`
 	);
+};
+
+type UpdateBlockOptions = {
+	incoming: {
+		content: string;
+		path: string;
+	};
+	current: {
+		content: string;
+		path: string;
+	};
+	config: {
+		formatter: ProjectConfig['formatter'];
+		prettierOptions: prettier.Options | null;
+		biomeOptions: PartialConfiguration | null;
+	};
+	options: {
+		yes: boolean;
+		no: boolean;
+		expand: boolean;
+		maxUnchanged: number;
+		verbose?: (msg: string) => void;
+		loading: ReturnType<typeof spinner>;
+	};
+};
+
+type UpdateBlockResult =
+	| {
+			applyChanges: true;
+			updatedContent: string;
+	  }
+	| {
+			applyChanges: false;
+	  };
+
+export const promptUpdateFile = async ({
+	incoming,
+	current,
+	config,
+	options,
+}: UpdateBlockOptions): Promise<UpdateBlockResult> => {
+	process.stdout.write(`${ascii.VERTICAL_LINE}\n`);
+
+	let acceptedChanges = false;
+
+	let hasUpdatedWithAI = false;
+	let updatedContent = incoming.content;
+
+	let model: ModelName = 'Claude 3.5 Sonnet';
+
+	while (true) {
+		const changes = diffLines(current.content, updatedContent);
+
+		// print diff
+		const formattedDiff = formatDiff({
+			from: incoming.path,
+			to: current.path,
+			changes,
+			expand: options.expand,
+			maxUnchanged: options.maxUnchanged,
+			prefix: () => `${ascii.VERTICAL_LINE}  `,
+			onUnchanged: ({ from, to, prefix }) =>
+				`${prefix?.() ?? ''}${color.cyan(from)} → ${color.gray(to)} ${color.gray('(unchanged)')}\n`,
+			intro: ({ from, to, changes, prefix }) => {
+				const totalChanges = changes.filter((a) => a.added || a.removed).length;
+
+				return `${prefix?.() ?? ''}${color.cyan(from)} → ${color.gray(to)} (${totalChanges} change${
+					totalChanges === 1 ? '' : 's'
+				})\n${prefix?.() ?? ''}\n`;
+			},
+		});
+
+		process.stdout.write(formattedDiff);
+
+		// if there are no changes then don't ask
+		if (changes.length > 1 || current.content === '') {
+			acceptedChanges = options.yes;
+
+			if (!options.yes && !options.no) {
+				const confirmOptions = [
+					{
+						label: 'Accept',
+						value: 'accept',
+					},
+					{
+						label: 'Reject',
+						value: 'reject',
+					},
+				];
+
+				if (hasUpdatedWithAI) {
+					confirmOptions.push(
+						{
+							label: `✨ ${color.yellow('Update with AI')} ✨ ${color.gray('(Iterate)')}`,
+							value: 'update-iterate',
+						},
+						{
+							label: `✨ ${color.yellow('Update with AI')} ✨ ${color.gray('(Retry)')}`,
+							value: 'update',
+						}
+					);
+				} else {
+					confirmOptions.push({
+						label: `✨ ${color.yellow('Update with AI')} ✨`,
+						value: 'update',
+					});
+				}
+
+				// prompt the user
+				const confirmResult = await select({
+					message: 'Accept changes?',
+					options: confirmOptions,
+				});
+
+				if (isCancel(confirmResult)) {
+					cancel('Canceled!');
+					process.exit(0);
+				}
+
+				if (confirmResult === 'update' || confirmResult === 'update-iterate') {
+					// prompt for model
+					const modelResult = await select({
+						message: 'Select a model',
+						options: Object.keys(models).map((key) => ({
+							label: key,
+							value: key,
+						})),
+						initialValue: model,
+					});
+
+					if (isCancel(modelResult)) {
+						cancel('Canceled!');
+						process.exit(0);
+					}
+
+					model = modelResult as ModelName;
+
+					const additionalInstructions = await text({
+						message: 'Any additional instructions?',
+						defaultValue: 'None',
+					});
+
+					if (isCancel(additionalInstructions)) {
+						cancel('Canceled!');
+						process.exit(0);
+					}
+
+					try {
+						updatedContent = await models[model].updateFile({
+							originalFile: current,
+							newFile: {
+								content:
+									confirmResult === 'update-iterate'
+										? updatedContent
+										: incoming.content,
+								path: incoming.path,
+							},
+							additionalInstructions:
+								additionalInstructions !== 'None'
+									? additionalInstructions
+									: undefined,
+							loading: options.loading,
+							verbose: options.verbose,
+						});
+					} catch (err) {
+						options.loading.stop();
+						log.error(color.red(`Error getting completions: ${err}`));
+						process.stdout.write(`${ascii.VERTICAL_LINE}\n`);
+						continue;
+					}
+
+					updatedContent = await formatFile({
+						file: {
+							content: updatedContent,
+							destPath: current.path,
+						},
+						biomeOptions: config.biomeOptions,
+						prettierOptions: config.prettierOptions,
+						formatter: config.formatter,
+					});
+
+					process.stdout.write(`${ascii.VERTICAL_LINE}\n`);
+
+					hasUpdatedWithAI = true;
+
+					continue;
+				}
+
+				acceptedChanges = confirmResult === 'accept';
+
+				break;
+			}
+		}
+
+		break; // there were no changes or changes were automatically accepted
+	}
+
+	if (acceptedChanges) {
+		return { applyChanges: true, updatedContent };
+	}
+
+	return { applyChanges: false };
 };
 
 export {

--- a/sites/docs/src/lib/components/ui/copy-button/copy-button.svelte
+++ b/sites/docs/src/lib/components/ui/copy-button/copy-button.svelte
@@ -6,7 +6,7 @@
 
 <script lang="ts">
 	import { Button, type ButtonProps } from '$lib/components/ui/button';
-	import { UseClipboard } from '../../../hooks/use-clipboard.svelte';
+	import { UseClipboard } from '$lib/hooks/use-clipboard.svelte';
 	import { cn } from '$lib/utils/utils';
 	import { Check, Copy, X } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';

--- a/sites/docs/static/docs/cli/llms.txt
+++ b/sites/docs/static/docs/cli/llms.txt
@@ -2,7 +2,7 @@
 
 > A CLI to add shared code from remote repositories.
  
-Latest Version: 1.35.0
+Latest Version: 1.35.1
 
 ## Commands
 
@@ -97,7 +97,7 @@ jsrepo init [options] [registries...]
 - -P, --project: Takes you through the steps to initialize a project. 
 - -R, --registry: Takes you through the steps to initialize a registry. 
 - --script <name>: The name of the build script. (For Registry setup) (default: build:registry)
-- -E, --expand: Expands the diff so you see everything. 
+- -E, --expand: Expands the diff so you see the entire file. 
 - --max-unchanged <number>: Maximum unchanged lines that will show without being collapsed. (default: 3)
 - -y, --yes: Skip confirmation prompt. 
 - --no-cache: Disable caching of resolved git urls. 
@@ -131,7 +131,7 @@ jsrepo update [options] [blocks...]
 
 #### Options
 - --all: Update all installed components. 
-- -E, --expand: Expands the diff so you see everything. 
+- -E, --expand: Expands the diff so you see the entire file. 
 - --max-unchanged <number>: Maximum unchanged lines that will show without being collapsed. (default: 3)
 - -n, --no: Do update any blocks. 
 - --repo <repo>: Repository to download the blocks from. 


### PR DESCRIPTION
- Add `Additional instructions:` prompt to allow for describing the changes you want when updating a file with an LLM
- Add the ability to iterate on a file change when updating with AI. This will give the AI the chat history as you iterate with it
- Provide your last model choice as the default for the select model prompt
- Consolidate logic for update file