### PR TITLE
feat!: Allow managing tokens for AI providers in auth command

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": {
 		".": {
@@ -34,10 +25,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",
@@ -56,7 +44,7 @@
 		"@types/validate-npm-package-name": "^4.0.2",
 		"tsup": "^8.3.6",
 		"typescript": "^5.7.3",
-		"vitest": "^3.0.5"
+		"vitest": "^3.0.6"
 	},
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.36.3",
@@ -84,7 +72,7 @@
 		"pathe": "^2.0.3",
 		"prettier": "^3.5.1",
 		"semver": "^7.7.1",
-		"svelte": "^5.20.1",
+		"svelte": "^5.20.2",
 		"ts-morph": "^25.0.1",
 		"valibot": "1.0.0-rc.1",
 		"validate-npm-package-name": "^6.0.0",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -38,6 +38,7 @@ import { returnShouldInstall } from '../utils/package';
 import * as persisted from '../utils/persisted';
 import { type Task, intro, nextSteps, promptUpdateFile, runTasks } from '../utils/prompts';
 import * as registry from '../utils/registry-providers/internal';
+import { TokenManager } from '../utils/token-manager';
 
 const schema = v.object({
 	repos: v.optional(v.array(v.string())),
@@ -480,7 +481,7 @@ const promptForProviderConfig = async ({
 }> => {
 	const loading = spinner();
 
-	const storage = persisted.get();
+	const storage = new TokenManager();
 
 	const provider = registry.selectProvider(repo);
 
@@ -492,9 +493,7 @@ const promptForProviderConfig = async ({
 		);
 	}
 
-	const tokenKey = `${provider.name}-token`;
-
-	const token = storage.get(tokenKey);
+	const token = storage.get(provider.name);
 
 	// don't ask if the provider is a custom domain
 	if (!token && provider.name !== registry.http.name && !options.yes) {
@@ -521,7 +520,7 @@ const promptForProviderConfig = async ({
 				process.exit(0);
 			}
 
-			storage.set(tokenKey, response);
+			storage.set(provider.name, response);
 		}
 	}
 

--- a/packages/cli/src/utils/ai.ts
+++ b/packages/cli/src/utils/ai.ts
@@ -4,6 +4,7 @@ import ollama from 'ollama';
 import OpenAI from 'openai';
 import * as lines from './blocks/ts/lines';
 import * as persisted from './persisted';
+import { TokenManager } from './token-manager';
 
 type File = {
 	path: string;
@@ -362,11 +363,9 @@ export const unwrapCodeFromQuotes = (quoted: string): string => {
  * @returns
  */
 const getApiKey = async (name: 'OpenAI' | 'Anthropic'): Promise<string> => {
-	const KEY = `${name}-api-key`;
+	const storage = new TokenManager();
 
-	const storage = persisted.get();
-
-	let apiKey = storage.get(KEY, null) as string | null;
+	let apiKey = storage.get(name);
 
 	if (!apiKey) {
 		// prompt for api key
@@ -385,7 +384,7 @@ const getApiKey = async (name: 'OpenAI' | 'Anthropic'): Promise<string> => {
 		apiKey = result;
 	}
 
-	storage.set(KEY, apiKey);
+	storage.set(name, apiKey);
 
 	return apiKey;
 };

--- a/packages/cli/src/utils/token-manager.ts
+++ b/packages/cli/src/utils/token-manager.ts
@@ -1,0 +1,32 @@
+import type Conf from 'conf';
+import * as persisted from './persisted';
+
+export class TokenManager {
+	#storage: Conf;
+
+	constructor(storage?: Conf) {
+		this.#storage = storage ?? persisted.get();
+	}
+
+	private getKey(name: string) {
+		return `${name}-token`;
+	}
+
+	get(name: string): string | undefined {
+		const key = this.getKey(name);
+
+		return this.#storage.get(key, undefined) as string | undefined;
+	}
+
+	set(name: string, secret: string) {
+		const key = this.getKey(name);
+
+		this.#storage.set(key, secret);
+	}
+
+	delete(name: string) {
+		const key = this.getKey(name);
+
+		this.#storage.delete(key);
+	}
+}

--- a/packages/cli/src/utils/token-manager.ts
+++ b/packages/cli/src/utils/token-manager.ts
@@ -9,7 +9,7 @@ export class TokenManager {
 	}
 
 	private getKey(name: string) {
-		return `${name}-token`;
+		return `${name}-token`.toLowerCase();
 	}
 
 	get(name: string): string | undefined {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^7.7.1
         version: 7.7.1
       svelte:
-        specifier: ^5.20.1
-        version: 5.20.1
+        specifier: ^5.20.2
+        version: 5.20.2
       ts-morph:
         specifier: ^25.0.1
         version: 25.0.1
@@ -130,8 +130,8 @@ importers:
         specifier: ^5.7.3
         version: 5.7.3
       vitest:
-        specifier: ^3.0.5
-        version: 3.0.5(@types/node@22.13.4)(jiti@1.21.7)(jsdom@26.0.0)(yaml@2.7.0)
+        specifier: ^3.0.6
+        version: 3.0.6(@types/node@22.13.4)(jiti@1.21.7)(jsdom@26.0.0)(yaml@2.7.0)
 
   sites/docs:
     devDependencies:
@@ -1293,11 +1293,11 @@ packages:
     resolution: {integrity: sha512-GeCAHLzKkL2kMFqatgqyiiNh+FILOSAV8x8imBDo6AWQ91w30Kaxw4FnzUDqgcd9z8aCYOBQ7RJxBBGfyr+USQ==}
     engines: {node: '>=18.16.0'}
 
-  '@vitest/expect@3.0.5':
-    resolution: {integrity: sha512-nNIOqupgZ4v5jWuQx2DSlHLEs7Q4Oh/7AYwNyE+k0UQzG7tSmjPXShUikn1mpNGzYEN2jJbTvLejwShMitovBA==}
+  '@vitest/expect@3.0.6':
+    resolution: {integrity: sha512-zBduHf/ja7/QRX4HdP1DSq5XrPgdN+jzLOwaTq/0qZjYfgETNFCKf9nOAp2j3hmom3oTbczuUzrzg9Hafh7hNg==}
 
-  '@vitest/mocker@3.0.5':
-    resolution: {integrity: sha512-CLPNBFBIE7x6aEGbIjaQAX03ZZlBMaWwAjBdMkIf/cAn6xzLTiM3zYqO/WAbieEjsAZir6tO71mzeHZoodThvw==}
+  '@vitest/mocker@3.0.6':
+    resolution: {integrity: sha512-KPztr4/tn7qDGZfqlSPQoF2VgJcKxnDNhmfR3VgZ6Fy1bO8T9Fc1stUiTXtqz0yG24VpD00pZP5f8EOFknjNuQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0
@@ -1307,20 +1307,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.0.5':
-    resolution: {integrity: sha512-CjUtdmpOcm4RVtB+up8r2vVDLR16Mgm/bYdkGFe3Yj/scRfCpbSi2W/BDSDcFK7ohw8UXvjMbOp9H4fByd/cOA==}
+  '@vitest/pretty-format@3.0.6':
+    resolution: {integrity: sha512-Zyctv3dbNL+67qtHfRnUE/k8qxduOamRfAL1BurEIQSyOEFffoMvx2pnDSSbKAAVxY0Ej2J/GH2dQKI0W2JyVg==}
 
-  '@vitest/runner@3.0.5':
-    resolution: {integrity: sha512-BAiZFityFexZQi2yN4OX3OkJC6scwRo8EhRB0Z5HIGGgd2q+Nq29LgHU/+ovCtd0fOfXj5ZI6pwdlUmC5bpi8A==}
+  '@vitest/runner@3.0.6':
+    resolution: {integrity: sha512-JopP4m/jGoaG1+CBqubV/5VMbi7L+NQCJTu1J1Pf6YaUbk7bZtaq5CX7p+8sY64Sjn1UQ1XJparHfcvTTdu9cA==}
 
-  '@vitest/snapshot@3.0.5':
-    resolution: {integrity: sha512-GJPZYcd7v8QNUJ7vRvLDmRwl+a1fGg4T/54lZXe+UOGy47F9yUfE18hRCtXL5aHN/AONu29NGzIXSVFh9K0feA==}
+  '@vitest/snapshot@3.0.6':
+    resolution: {integrity: sha512-qKSmxNQwT60kNwwJHMVwavvZsMGXWmngD023OHSgn873pV0lylK7dwBTfYP7e4URy5NiBCHHiQGA9DHkYkqRqg==}
 
-  '@vitest/spy@3.0.5':
-    resolution: {integrity: sha512-5fOzHj0WbUNqPK6blI/8VzZdkBlQLnT25knX0r4dbZI9qoZDf3qAdjoMmDcLG5A83W6oUUFJgUd0EYBc2P5xqg==}
+  '@vitest/spy@3.0.6':
+    resolution: {integrity: sha512-HfOGx/bXtjy24fDlTOpgiAEJbRfFxoX3zIGagCqACkFKKZ/TTOE6gYMKXlqecvxEndKFuNHcHqP081ggZ2yM0Q==}
 
-  '@vitest/utils@3.0.5':
-    resolution: {integrity: sha512-N9AX0NUoUtVwKwy21JtwzaqR5L5R5A99GAbrHfCCXK1lp593i/3AZAXhSP43wRQuxYsflrdzEfXZFo1reR1Nkg==}
+  '@vitest/utils@3.0.6':
+    resolution: {integrity: sha512-18ktZpf4GQFTbf9jK543uspU03Q2qya7ZGya5yiZ0Gx0nnnalBvd5ZBislbl2EhLjM8A8rt4OilqKG7QwcGkvQ==}
 
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
@@ -1557,8 +1557,8 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  chai@5.1.2:
-    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
 
   chalk@4.1.2:
@@ -2345,6 +2345,9 @@ packages:
   loupe@3.1.2:
     resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
 
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -3085,6 +3088,10 @@ packages:
     resolution: {integrity: sha512-aCARru2WTdzJl55Ws8SK27+kvQwd8tijl4kY7NoDUXUHtTHhxMa8Lf6QNZKmU7cuPu3jjFloDO1j5HgYJNIIWg==}
     engines: {node: '>=18'}
 
+  svelte@5.20.2:
+    resolution: {integrity: sha512-aYXJreNUiyTob0QOzRZeBXZMGeFZDch6SrSRV8QTncZb6zj0O3BEdUzPpojuHQ1pTvk+KX7I6rZCXPUf8pTPxA==}
+    engines: {node: '>=18'}
+
   sveltekit-superforms@2.23.1:
     resolution: {integrity: sha512-SPj5ac4SMg8SPyP0Zi3ynwXJa7r9U1CTyn+YSyck67zLsjt367Sro4SZnl3yASrLd5kJ6Y57cgIdYJ2aWNArXw==}
     peerDependencies:
@@ -3397,50 +3404,10 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite-node@3.0.5:
-    resolution: {integrity: sha512-02JEJl7SbtwSDJdYS537nU6l+ktdvcREfLksk/NDAqtdKWGqHl+joXzEubHROmS3E6pip+Xgu2tFezMu75jH7A==}
+  vite-node@3.0.6:
+    resolution: {integrity: sha512-s51RzrTkXKJrhNbUzQRsarjmAae7VmMPAsRT7lppVpIg6mK3zGthP9Hgz0YQQKuNcF+Ii7DfYk3Fxz40jRmePw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
-
-  vite@6.0.11:
-    resolution: {integrity: sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      jiti: '>=1.21.0'
-      less: '*'
-      lightningcss: ^1.21.0
-      sass: '*'
-      sass-embedded: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.16.0
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      jiti:
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
 
   vite@6.1.0:
     resolution: {integrity: sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==}
@@ -3490,16 +3457,16 @@ packages:
       vite:
         optional: true
 
-  vitest@3.0.5:
-    resolution: {integrity: sha512-4dof+HvqONw9bvsYxtkfUp2uHsTN9bV2CZIi1pWgoFpL1Lld8LA1ka9q/ONSsoScAKG7NVGf2stJTI7XRkXb2Q==}
+  vitest@3.0.6:
+    resolution: {integrity: sha512-/iL1Sc5VeDZKPDe58oGK4HUFLhw6b5XdY1MYawjuSaDA4sEfYlY9HnS6aCEG26fX+MgUi7MwlduTBHHAI/OvMA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/debug': ^4.1.12
       '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.0.5
-      '@vitest/ui': 3.0.5
+      '@vitest/browser': 3.0.6
+      '@vitest/ui': 3.0.6
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -4814,44 +4781,44 @@ snapshots:
       validator: 13.12.0
     optional: true
 
-  '@vitest/expect@3.0.5':
+  '@vitest/expect@3.0.6':
     dependencies:
-      '@vitest/spy': 3.0.5
-      '@vitest/utils': 3.0.5
-      chai: 5.1.2
+      '@vitest/spy': 3.0.6
+      '@vitest/utils': 3.0.6
+      chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(vite@6.0.11(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0))':
+  '@vitest/mocker@3.0.6(vite@6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0))':
     dependencies:
-      '@vitest/spy': 3.0.5
+      '@vitest/spy': 3.0.6
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.0.11(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)
 
-  '@vitest/pretty-format@3.0.5':
+  '@vitest/pretty-format@3.0.6':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.0.5':
+  '@vitest/runner@3.0.6':
     dependencies:
-      '@vitest/utils': 3.0.5
+      '@vitest/utils': 3.0.6
       pathe: 2.0.3
 
-  '@vitest/snapshot@3.0.5':
+  '@vitest/snapshot@3.0.6':
     dependencies:
-      '@vitest/pretty-format': 3.0.5
+      '@vitest/pretty-format': 3.0.6
       magic-string: 0.30.17
       pathe: 2.0.3
 
-  '@vitest/spy@3.0.5':
+  '@vitest/spy@3.0.6':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@3.0.5':
+  '@vitest/utils@3.0.6':
     dependencies:
-      '@vitest/pretty-format': 3.0.5
-      loupe: 3.1.2
+      '@vitest/pretty-format': 3.0.6
+      loupe: 3.1.3
       tinyrainbow: 2.0.0
 
   '@vue/compiler-core@3.5.13':
@@ -5098,7 +5065,7 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@5.1.2:
+  chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
@@ -5953,6 +5920,8 @@ snapshots:
 
   loupe@3.1.2: {}
 
+  loupe@3.1.3: {}
+
   lru-cache@10.4.3: {}
 
   lucide-svelte@0.475.0(svelte@5.20.1):
@@ -6664,6 +6633,23 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
+  svelte@5.20.2:
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@types/estree': 1.0.6
+      acorn: 8.14.0
+      acorn-typescript: 1.4.13(acorn@8.14.0)
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      esm-env: 1.2.2
+      esrap: 1.4.3
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.17
+      zimmerframe: 1.1.2
+
   sveltekit-superforms@2.23.1(@sveltejs/kit@2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.1)(vite@6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.1)(vite@6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)))(@types/json-schema@7.0.15)(svelte@5.20.1)(typescript@5.7.3):
     dependencies:
       '@sveltejs/kit': 2.17.2(@sveltejs/vite-plugin-svelte@5.0.3(svelte@5.20.1)(vite@6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)))(svelte@5.20.1)(vite@6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0))
@@ -6980,13 +6966,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.0.5(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0):
+  vite-node@3.0.6(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.0.11(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7000,17 +6986,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vite@6.0.11(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0):
-    dependencies:
-      esbuild: 0.24.2
-      postcss: 8.5.1
-      rollup: 4.31.0
-    optionalDependencies:
-      '@types/node': 22.13.4
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      yaml: 2.7.0
 
   vite@6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0):
     dependencies:
@@ -7027,16 +7002,16 @@ snapshots:
     optionalDependencies:
       vite: 6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)
 
-  vitest@3.0.5(@types/node@22.13.4)(jiti@1.21.7)(jsdom@26.0.0)(yaml@2.7.0):
+  vitest@3.0.6(@types/node@22.13.4)(jiti@1.21.7)(jsdom@26.0.0)(yaml@2.7.0):
     dependencies:
-      '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(vite@6.0.11(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0))
-      '@vitest/pretty-format': 3.0.5
-      '@vitest/runner': 3.0.5
-      '@vitest/snapshot': 3.0.5
-      '@vitest/spy': 3.0.5
-      '@vitest/utils': 3.0.5
-      chai: 5.1.2
+      '@vitest/expect': 3.0.6
+      '@vitest/mocker': 3.0.6(vite@6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0))
+      '@vitest/pretty-format': 3.0.6
+      '@vitest/runner': 3.0.6
+      '@vitest/snapshot': 3.0.6
+      '@vitest/spy': 3.0.6
+      '@vitest/utils': 3.0.6
+      chai: 5.2.0
       debug: 4.4.0
       expect-type: 1.1.0
       magic-string: 0.30.17
@@ -7046,8 +7021,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.0.11(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)
-      vite-node: 3.0.5(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)
+      vite-node: 3.0.6(@types/node@22.13.4)(jiti@1.21.7)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.4

--- a/sites/docs/src/routes/docs/+layout.svelte
+++ b/sites/docs/src/routes/docs/+layout.svelte
@@ -82,72 +82,74 @@
 	let { children } = $props();
 </script>
 
-<div class="relative xl:grid-cols-[1fr_300px] py-8 xl:grid xl:gap-10 flex justify-center w-full">
-	<div
-		class="flex flex-col gap-5 w-full justify-between flex-grow max-w-3xl px-6 lg:px-12"
-		style="min-height: calc(100svh - 56px)"
-	>
-		<div class="flex flex-col gap-5">
-			<Breadcrumb.Root>
-				<Breadcrumb.List>
-					<Breadcrumb.Item>
-						<Breadcrumb.Link href="/docs">Docs</Breadcrumb.Link>
-					</Breadcrumb.Item>
-					<Breadcrumb.Separator />
-					{#if currentDoc}
-						{#if currentDoc.parent}
-							<Breadcrumb.Item>
-								<Breadcrumb.Link href={currentDoc.parent.href}>
-									{currentDoc.parent.name}
-								</Breadcrumb.Link>
-							</Breadcrumb.Item>
-							<Breadcrumb.Separator />
-						{/if}
+<div>
+	<div class="relative xl:grid-cols-[1fr_300px] py-8 xl:grid xl:gap-10 flex justify-center w-full">
+		<div
+			class="flex flex-col gap-5 w-full justify-between flex-grow max-w-3xl px-6 lg:px-12"
+			style="min-height: calc(100svh - 56px)"
+		>
+			<div class="flex flex-col gap-5">
+				<Breadcrumb.Root>
+					<Breadcrumb.List>
 						<Breadcrumb.Item>
-							<Breadcrumb.Page>{currentDoc.route.name}</Breadcrumb.Page>
+							<Breadcrumb.Link href="/docs">Docs</Breadcrumb.Link>
 						</Breadcrumb.Item>
-					{/if}
-				</Breadcrumb.List>
-			</Breadcrumb.Root>
-			{@render children?.()}
+						<Breadcrumb.Separator />
+						{#if currentDoc}
+							{#if currentDoc.parent}
+								<Breadcrumb.Item>
+									<Breadcrumb.Link href={currentDoc.parent.href}>
+										{currentDoc.parent.name}
+									</Breadcrumb.Link>
+								</Breadcrumb.Item>
+								<Breadcrumb.Separator />
+							{/if}
+							<Breadcrumb.Item>
+								<Breadcrumb.Page>{currentDoc.route.name}</Breadcrumb.Page>
+							</Breadcrumb.Item>
+						{/if}
+					</Breadcrumb.List>
+				</Breadcrumb.Root>
+				{@render children?.()}
+			</div>
+			{#if currentDoc}
+				<div class="flex w-full justify-between place-items-center gap-4 pt-9">
+					<div>
+						{#if currentDoc.previous}
+							<Pagination.Previous href={currentDoc.previous.href}>
+								{currentDoc.previous.name}
+							</Pagination.Previous>
+						{:else if currentDoc.parent}
+							<Pagination.Previous href={currentDoc.parent.href}>
+								{currentDoc.parent.name}
+							</Pagination.Previous>
+						{/if}
+					</div>
+					<div>
+						{#if currentDoc.next}
+							<Pagination.Next href={currentDoc.next.href}>
+								{currentDoc.next.name}
+							</Pagination.Next>
+						{/if}
+					</div>
+				</div>
+			{/if}
 		</div>
-		{#if currentDoc}
-			<div class="flex w-full justify-between place-items-center gap-4 pt-9">
-				<div>
-					{#if currentDoc.previous}
-						<Pagination.Previous href={currentDoc.previous.href}>
-							{currentDoc.previous.name}
-						</Pagination.Previous>
-					{:else if currentDoc.parent}
-						<Pagination.Previous href={currentDoc.parent.href}>
-							{currentDoc.parent.name}
-						</Pagination.Previous>
-					{/if}
+		<div class="xl:flex flex-col hidden py-8 -mt-10 gap-3 sticky top-14 h-[calc(100vh-3.5rem)]">
+			{#if pageHeadings && pageHeadings.length > 0}
+				<p class="font-semibold text-sm">On This Page</p>
+				<div class="flex flex-col gap-1">
+					{#each pageHeadings as heading}
+						<a
+							href="#{heading.el.innerText}"
+							class="text-muted-foreground text-sm hover:text-foreground hover:dark:text-primary transition-all data-[active=true]:text-foreground data-[active=true]:dark:text-primary"
+							data-active={activeHeading === heading.el.innerText}
+						>
+							{heading.el.innerText}
+						</a>
+					{/each}
 				</div>
-				<div>
-					{#if currentDoc.next}
-						<Pagination.Next href={currentDoc.next.href}>
-							{currentDoc.next.name}
-						</Pagination.Next>
-					{/if}
-				</div>
-			</div>
-		{/if}
-	</div>
-	<div class="xl:flex flex-col hidden py-8 -mt-10 gap-3 sticky top-14 h-[calc(100vh-3.5rem)]">
-		{#if pageHeadings && pageHeadings.length > 0}
-			<p class="font-semibold text-sm">On This Page</p>
-			<div class="flex flex-col gap-1">
-				{#each pageHeadings as heading}
-					<a
-						href="#{heading.el.innerText}"
-						class="text-muted-foreground text-sm hover:text-foreground hover:dark:text-primary transition-all data-[active=true]:text-foreground data-[active=true]:dark:text-primary"
-						data-active={activeHeading === heading.el.innerText}
-					>
-						{heading.el.innerText}
-					</a>
-				{/each}
-			</div>
-		{/if}
+			{/if}
+		</div>
 	</div>
 </div>

--- a/sites/docs/src/routes/docs/cli/add/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/add/+page.svelte
@@ -8,16 +8,16 @@
 <Snippet command="execute" args={['jsrepo', 'add']} />
 <SubHeading>Usage</SubHeading>
 <p>
-	Choose a block to add from the registries in your <CodeSpan>jsrepo.json</CodeSpan> file.
+	Choose a block to add from the registries in your <CodeSpan>jsrepo.json</CodeSpan> file:
 </p>
 <Snippet command="execute" args={['jsrepo', 'add']} />
 <p>
-	Add a partially qualified block using the registries in your <CodeSpan>jsrepo.json</CodeSpan> file.
+	Add a partially qualified block using the registries in your <CodeSpan>jsrepo.json</CodeSpan> file:
 </p>
 <Snippet command="execute" args={['jsrepo', 'add', 'utils/math']} />
-<p>Add a fully qualified block.</p>
+<p>Add a fully qualified block:</p>
 <Snippet command="execute" args={['jsrepo', 'add', 'github/ieedan/std/utils/math']} />
-<p>Include another registry in the blocks list.</p>
+<p>Include another registry in the blocks list:</p>
 <Snippet command="execute" args={['jsrepo', 'add', '--repo', 'github/ieedan/std']} />
 <SubHeading>Options</SubHeading>
 <OptionDocs name="--repo">

--- a/sites/docs/src/routes/docs/cli/auth/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/auth/+page.svelte
@@ -1,34 +1,35 @@
 <script lang="ts">
-	import { CodeSpan, DocHeader, SubHeading } from '$lib/components/site/docs';
+	import { DocHeader, SubHeading } from '$lib/components/site/docs';
 	import { Snippet } from '$lib/components/ui/snippet';
 	import OptionDocs from '../option-docs.svelte';
 </script>
 
-<DocHeader title="auth" description="Configure access tokens for private repository access." />
+<DocHeader
+	title="auth"
+	description="Configure access tokens for private repository access and update with AI."
+/>
 <Snippet command="execute" args={['jsrepo', 'auth']} />
 <SubHeading>Usage</SubHeading>
+<p>Choose a service and provide a token:</p>
 <Snippet command="execute" args={['jsrepo', 'auth']} />
+<p>Authenticate to a specific service:</p>
+<Snippet command="execute" args={['jsrepo', 'auth']} />
+<p>Choose a service to logout from:</p>
+<Snippet command="execute" args={['jsrepo', 'auth', '--logout']} />
+<p>Logout from a specific service:</p>
+<Snippet command="execute" args={['jsrepo', 'auth', 'github', '--logout']} />
 <SubHeading>Options</SubHeading>
 <OptionDocs name="--token">
 	{#snippet description()}
-		The token to use for authenticating to your provider.
+		The token to use for authenticating to your service.
 	{/snippet}
 	{#snippet usage()}
 		<Snippet command="execute" args={['jsrepo', 'auth', '--token', 'xxxxxxxxxxx']} />
 	{/snippet}
 </OptionDocs>
-<OptionDocs name="--provider">
-	{#snippet description()}
-		The provider to store the token for. (<CodeSpan>github</CodeSpan>, <CodeSpan>gitlab</CodeSpan>,
-		<CodeSpan>bitbucket</CodeSpan>, <CodeSpan>azure</CodeSpan>).
-	{/snippet}
-	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'auth', '--provider', 'github']} />
-	{/snippet}
-</OptionDocs>
 <OptionDocs name="--logout">
 	{#snippet description()}
-		Changes to an interactive logout where you choose the provider to remove the token from.
+		Executes the logout flow.
 	{/snippet}
 	{#snippet usage()}
 		<Snippet command="execute" args={['jsrepo', 'auth', '--logout']} />

--- a/sites/docs/src/routes/docs/cli/exec/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/exec/+page.svelte
@@ -8,21 +8,21 @@
 <Snippet command="execute" args={['jsrepo', 'exec']} />
 <SubHeading>Usage</SubHeading>
 <p>
-	Choose a script to execute from the registries in your <CodeSpan>jsrepo.json</CodeSpan> file.
+	Choose a script to execute from the registries in your <CodeSpan>jsrepo.json</CodeSpan> file:
 </p>
 <Snippet command="execute" args={['jsrepo', 'exec']} />
 <p>
-	<CodeSpan>x</CodeSpan> alias.
+	<CodeSpan>x</CodeSpan> alias:
 </p>
 <Snippet command="execute" args={['jsrepo', 'x']} />
-<p>Execute with args.</p>
+<p>Execute with args:</p>
 <Snippet command="execute" args={['jsrepo', 'exec', '--', 'argument', '--yes']} />
 <p>
 	Execute a partially qualified script using the registries in your <CodeSpan>jsrepo.json</CodeSpan>
-	file.
+	file:
 </p>
 <Snippet command="execute" args={['jsrepo', 'exec', 'github/ieedan/scripts/general/hello']} />
-<p>Include another registry in the scripts list.</p>
+<p>Include another registry in the scripts list:</p>
 <Snippet command="execute" args={['jsrepo', 'exec', '--repo', 'github/ieedan/scripts']} />
 <SubHeading>Options</SubHeading>
 <OptionDocs name="--">

--- a/sites/docs/src/routes/docs/cli/init/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/init/+page.svelte
@@ -7,13 +7,13 @@
 <DocHeader title="init" description="Initialize a registry or project with jsrepo." />
 <Snippet command="execute" args={['jsrepo', 'init']} />
 <SubHeading>Usage</SubHeading>
-<p>Choose to initialize a registry or project.</p>
+<p>Choose to initialize a registry or project:</p>
 <Snippet command="execute" args={['jsrepo', 'init']} />
-<p>Initialize a project.</p>
+<p>Initialize a project:</p>
 <Snippet command="execute" args={['jsrepo', 'init', '--project']} />
-<p>Initialize a registry.</p>
+<p>Initialize a registry:</p>
 <Snippet command="execute" args={['jsrepo', 'init', '--registry']} />
-<p>Initialize a project with registries.</p>
+<p>Initialize a project with registries:</p>
 <Snippet command="execute" args={['jsrepo', 'init', 'github/ieedan/std']} />
 <SubHeading>Options</SubHeading>
 <OptionDocs name="--repos" deprecated>

--- a/sites/docs/src/routes/docs/cli/update/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/update/+page.svelte
@@ -18,9 +18,9 @@
 />
 <Snippet command="execute" args={['jsrepo', 'update']} />
 <SubHeading>Usage</SubHeading>
-<p>Choose which blocks to update.</p>
+<p>Choose which blocks to update:</p>
 <Snippet command="execute" args={['jsrepo', 'update']} />
-<p>Update a specific block.</p>
+<p>Update a specific block:</p>
 <Snippet command="execute" args={['jsrepo', 'update', 'utils/math']} />
 <SubHeading>✨ Update with AI ✨</SubHeading>
 <p>

--- a/sites/docs/static/docs/cli/llms.txt
+++ b/sites/docs/static/docs/cli/llms.txt
@@ -2,7 +2,7 @@
 
 > A CLI to add shared code from remote repositories.
  
-Latest Version: 1.35.1
+Latest Version: 1.37.0
 
 ## Commands
 
@@ -29,13 +29,12 @@ Provide a token for access to private repositories.
 
 #### Usage
 ```bash
-jsrepo auth [options]
+jsrepo auth [options] [service]
 ```
 
 #### Options
-- --token <token>: The token to use for authenticating to your provider. 
-- --provider <name>: The provider this token belongs to. 
-- --logout: Erase tokens from each provider from storage. 
+- --logout: Execute the logout flow. 
+- --token <token>: The token to use for authenticating to this service. 
 
 ### build
     


### PR DESCRIPTION
Fixes #431 

This allows you to manage OpenAI and Anthropic tokens as well as tokens for all the git providers.

This isn't breaking but you will need to update your tokens for using the newer version.