### PR TITLE
chore: use async version of detect

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": {
 		".": {
@@ -34,10 +25,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",
@@ -79,7 +67,7 @@
 		"octokit": "^4.1.2",
 		"ollama": "^0.5.14",
 		"openai": "^4.85.4",
-		"package-manager-detector": "^0.2.9",
+		"package-manager-detector": "^0.2.11",
 		"parse5": "^7.2.1",
 		"pathe": "^2.0.3",
 		"prettier": "^3.5.2",

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -5,7 +5,7 @@ import boxen from 'boxen';
 import color from 'chalk';
 import { program } from 'commander';
 import { diffLines } from 'diff';
-import { type Agent, detectSync, resolveCommand } from 'package-manager-detector';
+import { type Agent, detect, resolveCommand } from 'package-manager-detector';
 import type * as prettier from 'prettier';
 import semver from 'semver';
 import { cursor, erase } from 'sisteransi';
@@ -133,8 +133,8 @@ export const truncatedList = (items: string[], maxLength = 3) => {
 	return `${truncated.join(', ')}${remaining > 0 ? ` and ${remaining} other(s)` : ''}`;
 };
 
-const newerVersionAvailable = (name: string, oldVersion: string, newVersion: string) => {
-	const pm = detectSync({ cwd: process.cwd() })?.agent ?? 'npm';
+const newerVersionAvailable = async (name: string, oldVersion: string, newVersion: string) => {
+	const pm = detect({ cwd: process.cwd() })?.agent ?? 'npm';
 
 	const installCommand = resolveCommand(pm, 'global', ['jsrepo@latest']);
 
@@ -164,7 +164,7 @@ const _intro = async () => {
 	if (latestVersion.isOk()) {
 		if (semver.lt(packageJson.version, latestVersion.unwrap())) {
 			console.info(
-				newerVersionAvailable(packageJson.name, packageJson.version, latestVersion.unwrap())
+				await newerVersionAvailable(packageJson.name, packageJson.version, latestVersion.unwrap())
 			);
 		}
 	}

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -134,7 +134,7 @@ export const truncatedList = (items: string[], maxLength = 3) => {
 };
 
 const newerVersionAvailable = async (name: string, oldVersion: string, newVersion: string) => {
-	const pm = detect({ cwd: process.cwd() })?.agent ?? 'npm';
+	const pm = (await detect({ cwd: process.cwd() }))?.agent ?? 'npm';
 
 	const installCommand = resolveCommand(pm, 'global', ['jsrepo@latest']);
 

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -164,7 +164,11 @@ const _intro = async () => {
 	if (latestVersion.isOk()) {
 		if (semver.lt(packageJson.version, latestVersion.unwrap())) {
 			console.info(
-				await newerVersionAvailable(packageJson.name, packageJson.version, latestVersion.unwrap())
+				await newerVersionAvailable(
+					packageJson.name,
+					packageJson.version,
+					latestVersion.unwrap()
+				)
 			);
 		}
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ importers:
         specifier: ^4.85.4
         version: 4.85.4(ws@8.18.0)(zod@3.24.1)
       package-manager-detector:
-        specifier: ^0.2.9
-        version: 0.2.9
+        specifier: ^0.2.11
+        version: 0.2.11
       parse5:
         specifier: ^7.2.1
         version: 7.2.1
@@ -2840,6 +2840,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
   package-manager-detector@0.2.9:
     resolution: {integrity: sha512-+vYvA/Y31l8Zk8dwxHhL3JfTuHPm6tlxM2A3GeQyl7ovYnSp1+mzAxClxaOr0qO1TtPxbQxetI7v5XqKLJZk7Q==}
 
@@ -3051,6 +3054,9 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  quansync@0.2.7:
+    resolution: {integrity: sha512-KZDFlN9/Si3CgKHZsIfLBsrjWKFjqu9KA0zDGJEQoQzPm5HWNDEFc2mkLeYUBBOwEJtxNBSMaNLE/GlvArIEfQ==}
 
   query-registry@3.0.1:
     resolution: {integrity: sha512-M9RxRITi2mHMVPU5zysNjctUT8bAPx6ltEXo/ir9+qmiM47Y7f0Ir3+OxUO5OjYAWdicBQRew7RtHtqUXydqlg==}
@@ -6557,6 +6563,10 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@0.2.11:
+    dependencies:
+      quansync: 0.2.7
+
   package-manager-detector@0.2.9: {}
 
   parent-module@1.0.1:
@@ -6717,6 +6727,8 @@ snapshots:
 
   pure-rand@6.1.0:
     optional: true
+
+  quansync@0.2.7: {}
 
   query-registry@3.0.1:
     dependencies:


### PR DESCRIPTION
We're having an internal debate right now about removing `detectSync` in favor of `detect` so that we don't have to distribute both versions. I'm proactively sending you a PR to avoid you having to do any work on your side in case that happens (still unclear if it will)