### PR TITLE
feat: Enable usage of self hosted gitlab registries with the `gitlab:` prefix

### DIFF
--- a/.changeset/heavy-dingos-create.md
+++ b/.changeset/heavy-dingos-create.md
@@ -1,0 +1,5 @@
+---
+"jsrepo": minor
+---
+
+feat: Enable usage of self hosted gitlab using the `gitlab:` prefix.

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -14,16 +14,6 @@ jobs:
               node-version: "20"
               cache: pnpm
 
-        - name: Run changed-files
-          id: changed-files
-          uses: tj-actions/changed-files@v44
-          with:
-            separator: ' '
-            dir_names: 'true'
-            dir_names_max_depth: '2' # truncates the path to packages/package-name
-            files: |
-                packages/**
-
         - name: Install dependencies
           run: pnpm install
 
@@ -31,8 +21,5 @@ jobs:
           run: pnpm build:cli
 
         - name: publish preview
-          if: ${{ steps.changed-files.outputs.all_changed_files_count > 0 }}
-          env:
-            CHANGED_DIRS: ${{ steps.changed-files.outputs.all_changed_files }}
           # run: |
           run: pnpm dlx pkg-pr-new publish './packages/cli'

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": {
 		".": {
@@ -34,10 +25,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/utils/registry-providers/gitlab.ts
+++ b/packages/cli/src/utils/registry-providers/gitlab.ts
@@ -112,10 +112,10 @@ export const gitlab: RegistryProvider = {
 		const { baseUrl, owner, repoName, ref } = state as GitLabProviderState;
 
 		return new URL(
-			`${encodeURIComponent(resourcePath)}/raw?ref=${ref}`,
 			u.join(
 				baseUrl,
-				`api/v4/projects/${encodeURIComponent(`${owner}/${repoName}`)}/repository/files/`
+				`api/v4/projects/${encodeURIComponent(`${owner}/${repoName}`)}`,
+				`repository/files/${encodeURIComponent(resourcePath)}/raw?ref=${ref}`
 			)
 		);
 	},

--- a/packages/cli/src/utils/registry-providers/index.ts
+++ b/packages/cli/src/utils/registry-providers/index.ts
@@ -42,6 +42,8 @@ export const fetchRaw = async (
 			headers.append(key, value);
 		}
 
+		console.log(url);
+
 		const response = await f(url, { headers });
 
 		verbose?.(`Got a response from ${url} ${response.status} ${response.statusText}`);

--- a/packages/cli/src/utils/registry-providers/index.ts
+++ b/packages/cli/src/utils/registry-providers/index.ts
@@ -42,8 +42,6 @@ export const fetchRaw = async (
 			headers.append(key, value);
 		}
 
-		console.log(url);
-
 		const response = await f(url, { headers });
 
 		verbose?.(`Got a response from ${url} ${response.status} ${response.statusText}`);

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -427,8 +427,6 @@ describe('gitlab', () => {
 		// this way we just get the text and skip the schema validation
 		const content = await registry.fetchRaw(providerState.unwrap(), 'jsrepo-manifest.json');
 
-		console.log(content.unwrapErr());
-
 		expect(content.unwrap()).toBe(`[
 	{
 		"name": "types",

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -608,6 +608,31 @@ describe('gitlab', () => {
 ]
 `);
 	});
+
+	it('Fetches the manifest with "gitlab" prefix', async () => {		
+		const repoURL = 'gitlab:https://gitlab.com/ieedan/std';
+
+		const providerState = await registry.getProviderState(repoURL);
+
+		assert(providerState.isOk());
+
+		const content = await registry.fetchManifest(providerState.unwrap());
+
+		expect(content.isErr()).toBe(false);
+	});
+
+	// this is just here to make sure fetch manifest is actually using the right url
+	it('Fails to fetch with incorrect prefixed url', async () => {		
+		const repoURL = 'gitlab:https://gitlab.om/ieedan/std';
+
+		const providerState = await registry.getProviderState(repoURL);
+
+		assert(providerState.isOk());
+
+		const content = await registry.fetchManifest(providerState.unwrap());
+
+		expect(content.isErr()).toBe(true);
+	});
 });
 
 describe('bitbucket', () => {

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -609,7 +609,7 @@ describe('gitlab', () => {
 `);
 	});
 
-	it('Fetches the manifest with "gitlab" prefix', async () => {		
+	it('Fetches the manifest with "gitlab" prefix', async () => {
 		const repoURL = 'gitlab:https://gitlab.com/ieedan/std';
 
 		const providerState = await registry.getProviderState(repoURL);
@@ -622,7 +622,7 @@ describe('gitlab', () => {
 	});
 
 	// this is just here to make sure fetch manifest is actually using the right url
-	it('Fails to fetch with incorrect prefixed url', async () => {		
+	it('Fails to fetch with incorrect prefixed url', async () => {
 		const repoURL = 'gitlab:https://gitlab.om/ieedan/std';
 
 		const providerState = await registry.getProviderState(repoURL);

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -305,7 +305,7 @@ describe('gitlab', () => {
 				url: 'https://gitlab.com/ieedan/std',
 				opts: { fullyQualified: false },
 				expected: {
-					url: 'gitlab/ieedan/std',
+					url: 'https://gitlab.com/ieedan/std',
 					specifier: undefined,
 				},
 			},
@@ -313,7 +313,7 @@ describe('gitlab', () => {
 				url: 'gitlab/ieedan/std',
 				opts: { fullyQualified: false },
 				expected: {
-					url: 'gitlab/ieedan/std',
+					url: 'https://gitlab.com/ieedan/std',
 					specifier: undefined,
 				},
 			},
@@ -321,7 +321,7 @@ describe('gitlab', () => {
 				url: 'gitlab/ieedan/std/-/tree/next',
 				opts: { fullyQualified: false },
 				expected: {
-					url: 'gitlab/ieedan/std/-/tree/next',
+					url: 'https://gitlab.com/ieedan/std/-/tree/next',
 					specifier: undefined,
 				},
 			},
@@ -329,7 +329,7 @@ describe('gitlab', () => {
 				url: 'https://gitlab.com/ieedan/std/-/tree/v2.0.0',
 				opts: { fullyQualified: false },
 				expected: {
-					url: 'gitlab/ieedan/std/-/tree/v2.0.0',
+					url: 'https://gitlab.com/ieedan/std/-/tree/v2.0.0',
 					specifier: undefined,
 				},
 			},
@@ -337,7 +337,7 @@ describe('gitlab', () => {
 				url: 'https://gitlab.com/ieedan/std/-/tree/v2.0.0?ref_type=tags',
 				opts: { fullyQualified: false },
 				expected: {
-					url: 'gitlab/ieedan/std/-/tree/v2.0.0',
+					url: 'https://gitlab.com/ieedan/std/-/tree/v2.0.0',
 					specifier: undefined,
 				},
 			},
@@ -345,7 +345,7 @@ describe('gitlab', () => {
 				url: 'https://gitlab.com/ieedan/std/utils/math',
 				opts: { fullyQualified: true },
 				expected: {
-					url: 'gitlab/ieedan/std',
+					url: 'https://gitlab.com/ieedan/std',
 					specifier: 'utils/math',
 				},
 			},
@@ -353,7 +353,7 @@ describe('gitlab', () => {
 				url: 'gitlab/ieedan/std/utils/math',
 				opts: { fullyQualified: true },
 				expected: {
-					url: 'gitlab/ieedan/std',
+					url: 'https://gitlab.com/ieedan/std',
 					specifier: 'utils/math',
 				},
 			},
@@ -361,8 +361,16 @@ describe('gitlab', () => {
 				url: 'gitlab/ieedan/std/-/tree/v2.0.0/utils/math',
 				opts: { fullyQualified: true },
 				expected: {
-					url: 'gitlab/ieedan/std/-/tree/v2.0.0',
+					url: 'https://gitlab.com/ieedan/std/-/tree/v2.0.0',
 					specifier: 'utils/math',
+				},
+			},
+			{
+				url: 'gitlab:https://example.com/ieedan/std',
+				opts: { fullyQualified: false },
+				expected: {
+					url: 'https://example.com/ieedan/std',
+					specifier: undefined,
 				},
 			},
 		];
@@ -383,8 +391,12 @@ describe('gitlab', () => {
 				expected: 'https://gitlab.com/ieedan/std',
 			},
 			{
-				url: 'gitlab/ieedan/std/tree/next',
+				url: 'gitlab/ieedan/std/-/tree/next',
 				expected: 'https://gitlab.com/ieedan/std',
+			},
+			{
+				url: 'gitlab:https://example.com/ieedan/std/-/tree/next',
+				expected: 'https://example.com/ieedan/std',
 			},
 		];
 
@@ -414,6 +426,8 @@ describe('gitlab', () => {
 
 		// this way we just get the text and skip the schema validation
 		const content = await registry.fetchRaw(providerState.unwrap(), 'jsrepo-manifest.json');
+
+		console.log(content.unwrapErr());
 
 		expect(content.unwrap()).toBe(`[
 	{

--- a/sites/docs/src/routes/docs/git-providers/gitlab/+page.svelte
+++ b/sites/docs/src/routes/docs/git-providers/gitlab/+page.svelte
@@ -74,3 +74,14 @@ https://gitlab.com/ieedan/std/-/tree/next # branch reference`}
 		}
 }`}
 />
+<SubHeading>Self hosted GitLab</SubHeading>
+<p>Some companies prefer to host their own GitLab instance so we allow that too!</p>
+<p>
+	You can use the <CodeSpan>gitlab:</CodeSpan> prefix followed by your custom domain to point to your
+	self hosted instance:
+</p>
+<Code lang="diff" hideLines hideCopy code={'gitlab:https://example.com/ieedan/std'} />
+<p>
+	Now requests will be made to <CodeSpan>https://example.com</CodeSpan> with the owner
+	<CodeSpan>ieedan</CodeSpan> and the repository name <CodeSpan>std</CodeSpan>.
+</p>


### PR DESCRIPTION
Fixes #492 

This adds a `gitlab:` prefix to allow you to specify a self hosted gitlab instance. 

For example if you hosted your gitlab instance at `https://example.com`:
```
gitlab:https://example.com/ieedan/std
```

## TODO
- [x] Testing on a real self hosted registry (taking volunteers)