### PR TITLE
fix: Test command import resolution

### DIFF
--- a/.changeset/heavy-llamas-lie.md
+++ b/.changeset/heavy-llamas-lie.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+fix: Ensure original import is quoted before replacing it in test files.
+  

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": {
 		".": {
@@ -34,10 +25,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -569,7 +569,7 @@ const _add = async (blockNames: string[], options: Options) => {
 
 					if (updateResult.applyChanges) {
 						updatedFiles.push(
-							promises.noopPromise({
+							promises.immediate({
 								destination: destPath,
 								content: updateResult.updatedContent,
 								block: preloadedBlock.block,

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { cancel, confirm, isCancel, outro } from '@clack/prompts';
 import color from 'chalk';
 import { Argument, Command, program } from 'commander';
+import escapeStringRegexp from 'escape-string-regexp';
 import { execa } from 'execa';
 import oxc from 'oxc-parser';
 import { resolveCommand } from 'package-manager-detector/commands';
@@ -266,7 +267,13 @@ const _test = async (blockNames: string[], options: Options) => {
 				}
 
 				if (newModuleSpecifier) {
-					code = code.replaceAll(moduleSpecifier, newModuleSpecifier);
+					// this way we only replace the exact import since it will be surrounded in quotes
+					const literalRegex = new RegExp(
+						`(['"])${escapeStringRegexp(moduleSpecifier)}\\1`,
+						'g'
+					);
+
+					code = code.replaceAll(literalRegex, `$1${newModuleSpecifier}$1`);
 				}
 			}
 

--- a/packages/cli/src/utils/blocks/ts/promises.ts
+++ b/packages/cli/src/utils/blocks/ts/promises.ts
@@ -4,13 +4,15 @@
 
 /** Returns a promise that immediately resolves to `T`, useful when you need to mix sync and async code.
  *
+ * @param val
+ *
  * ### Usage
  * ```ts
  * const promises: Promise<number>[] = [];
  *
- * promises.push(noopPromise(10));
+ * promises.push(immediate(10));
  * ```
- *
- * @param val
  */
-export const noopPromise = <T>(val: T) => new Promise<T>((res) => res(val));
+export function immediate<T>(val: T): Promise<T> {
+	return new Promise<T>((res) => res(val));
+}


### PR DESCRIPTION
Fixes instances where imports would be replaced when not quoted. This would cause issues if your import was for instance `.` where all instances of `.` in the file would become the new import.