### PR TITLE
fix: Delete outdated cache when using `--no-cache`

### DIFF
--- a/.changeset/hip-friends-hug.md
+++ b/.changeset/hip-friends-hug.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+fix: Delete outdated state cache entries when using `--no-cache`
+  

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,16 +15,7 @@
 	"bugs": {
 		"url": "https://github.com/ieedan/jsrepo/issues"
 	},
-	"keywords": [
-		"repo",
-		"cli",
-		"svelte",
-		"vue",
-		"typescript",
-		"javascript",
-		"shadcn",
-		"registry"
-	],
+	"keywords": ["repo", "cli", "svelte", "vue", "typescript", "javascript", "shadcn", "registry"],
 	"type": "module",
 	"exports": {
 		".": {
@@ -34,10 +25,7 @@
 	},
 	"bin": "./dist/index.js",
 	"main": "./dist/index.js",
-	"files": [
-		"./schemas/**/*",
-		"dist/**/*"
-	],
+	"files": ["./schemas/**/*", "dist/**/*"],
 	"scripts": {
 		"start": "tsup --silent && node ./dist/index.js",
 		"build": "tsup",

--- a/packages/cli/src/utils/registry-providers/internal.ts
+++ b/packages/cli/src/utils/registry-providers/internal.ts
@@ -75,9 +75,14 @@ export const getProviderState = async (
 
 		// only git providers are cached
 		if (provider.name !== http.name && !noCache) {
-			const cached = storage.get(`${repo}-state`);
+			if (noCache) {
+				// remove the outdated cache if it exists
+				storage.delete(`${repo}-state`);
+			} else {
+				const cached = storage.get(`${repo}-state`);
 
-			if (cached) return Ok({ ...(cached as RegistryProviderState), provider });
+				if (cached) return Ok({ ...(cached as RegistryProviderState), provider });
+			}
 		}
 
 		const parsed = provider.parse(repo, { fullyQualified: false });


### PR DESCRIPTION
Since entries in the state cache live forever the it only makes sense that the `--no-cache` flag should cause them to be removed to prevent issues where you can never update the cache again.