### PR TITLE
fix: ensure options don't interfere with config

### DIFF
--- a/.changeset/clean-mammals-switch.md
+++ b/.changeset/clean-mammals-switch.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+fix: ensure package with unpinned version isn't installed if already installed in the users project
+  

--- a/.changeset/hip-lamps-walk.md
+++ b/.changeset/hip-lamps-walk.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": minor
+---
+
+fix: Update args for `add` so that config takes priority as expected
+  

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -63,12 +63,16 @@ export const add = new Command('add')
 			'biome',
 		])
 	)
-	.option(
-		'--no-watermark',
-		"jsrepo shouldn't leave a watermark at the top of the added files.",
-		undefined
+	.addOption(
+		new Option('--watermark <choice>', 'Include a watermark at the top of added files.')
+			.choices(['true', 'false'])
+			.argParser((val) => val === 'true')
 	)
-	.option('--no-tests', "jsrepo shouldn't include tests when adding blocks.", undefined)
+	.addOption(
+		new Option('--tests <choice>', 'Include tests when adding blocks.')
+			.choices(['true', 'false'])
+			.argParser((val) => val === 'true')
+	)
 	.option(
 		'--paths <category=path,category=path>',
 		'The paths where categories should be added to your project.',

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -37,7 +37,7 @@ import * as registry from '../utils/registry-providers/internal';
 const schema = v.object({
 	watermark: v.optional(v.boolean()),
 	tests: v.optional(v.boolean()),
-	formatter: v.optional(formatterSchema),
+	formatter: v.optional(v.union([v.literal('prettier'), v.literal('biome'), v.literal('none')])),
 	paths: v.optional(v.record(v.string(), v.string())),
 	expand: v.boolean(),
 	maxUnchanged: v.number(),
@@ -61,6 +61,7 @@ export const add = new Command('add')
 		new Option('--formatter <choice>', 'The formatter to use when adding blocks.').choices([
 			'prettier',
 			'biome',
+			'none',
 		])
 	)
 	.addOption(
@@ -156,7 +157,10 @@ async function _add(blockNames: string[], options: Options) {
 		config = configResult.unwrap();
 	}
 
-	config.formatter = options.formatter !== undefined ? options.formatter : config.formatter;
+	config.formatter =
+		options.formatter !== undefined && options.formatter !== 'none'
+			? options.formatter
+			: config.formatter;
 	config.watermark = options.watermark !== undefined ? options.watermark : config.watermark;
 	config.includeTests = options.tests !== undefined ? options.tests : config.includeTests;
 	config.paths =

--- a/packages/cli/src/utils/package.ts
+++ b/packages/cli/src/utils/package.ts
@@ -74,7 +74,7 @@ function returnShouldInstall(
 				}
 
 				// if the version installed satisfies the requested version remove the dep
-				if (foundDep && semver.satisfies(cleanVersion(foundDep), version)) {
+				if (foundDep && semver.satisfies(cleanVersion(foundDep), version!)) {
 					tempDeps.delete(dep);
 				}
 			}
@@ -94,7 +94,7 @@ function returnShouldInstall(
 				}
 
 				// if the version installed satisfies the requested version remove the dep
-				if (foundDep && semver.satisfies(cleanVersion(foundDep), version)) {
+				if (foundDep && semver.satisfies(cleanVersion(foundDep), version!)) {
 					tempDevDeps.delete(dep);
 				}
 			}

--- a/packages/cli/src/utils/parse-package-name.ts
+++ b/packages/cli/src/utils/parse-package-name.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-import { Err, Ok, type Result } from './blocks/ts/result';
+import { Err, Ok } from './blocks/ts/result';
 
 // Parsed a scoped package name into name, version, and path.
 const RE_SCOPED = /^(@[^\/]+\/[^@\/]+)(?:@([^\/]+))?(\/.*)?$/;
@@ -14,11 +14,11 @@ export type Package = {
 	/** Name of the package as it would be installed from npm */
 	name: string;
 	/** Version of the package */
-	version: string | undefined;
+	version: string;
 	path: string;
 };
 
-export function parsePackageName(input: string): Result<Package, string> {
+export function parsePackageName(input: string) {
 	const m = RE_SCOPED.exec(input) || RE_NON_SCOPED.exec(input);
 
 	if (!m) return Err(`invalid package name: ${input}`);

--- a/packages/cli/src/utils/parse-package-name.ts
+++ b/packages/cli/src/utils/parse-package-name.ts
@@ -14,20 +14,18 @@ export type Package = {
 	/** Name of the package as it would be installed from npm */
 	name: string;
 	/** Version of the package */
-	version: string;
+	version: string | undefined;
 	path: string;
 };
 
-function parsePackageName(input: string): Result<Package, string> {
+export function parsePackageName(input: string): Result<Package, string> {
 	const m = RE_SCOPED.exec(input) || RE_NON_SCOPED.exec(input);
 
 	if (!m) return Err(`invalid package name: ${input}`);
 
 	return Ok({
 		name: m[1] || '',
-		version: m[2] || 'latest',
+		version: m[2] || undefined,
 		path: m[3] || '',
 	});
 }
-
-export { parsePackageName };

--- a/packages/cli/tests/add.test.ts
+++ b/packages/cli/tests/add.test.ts
@@ -3,6 +3,7 @@ import { execa } from 'execa';
 import path from 'pathe';
 import { afterAll, beforeAll, describe, it } from 'vitest';
 import { cli } from '../src/cli';
+import * as u from '../src/utils/blocks/ts/url';
 import type { ProjectConfig } from '../src/utils/config';
 import { assertFilesExist } from './utils';
 
@@ -24,6 +25,27 @@ describe('add', () => {
 		fs.writeFileSync('jsrepo.json', JSON.stringify(config));
 
 		await cli.parseAsync(['node', 'jsrepo', 'add', block, '-y', '--verbose', '--cwd', testDir]);
+	};
+
+	const addBlockZeroConfig = async (registry: string, block: `${string}/${string}`) => {
+		await cli.parseAsync([
+			'node',
+			'jsrepo',
+			'add',
+			u.join(registry, block),
+			'--formatter',
+			'none',
+			'--watermark',
+			'true',
+			'--tests',
+			'false',
+			'--paths',
+			"'*=./src'",
+			'-y',
+			'--verbose',
+			'--cwd',
+			testDir,
+		]);
 	};
 
 	beforeAll(async () => {
@@ -125,5 +147,13 @@ describe('add', () => {
 		];
 
 		assertFilesExist(blockBaseDir, ...expectedFiles);
+	});
+
+	it('adds with zero-config without interaction', async () => {
+		await addBlockZeroConfig('github/ieedan/std', 'ts/is-letter');
+
+		const blockBaseDir = './src/ts';
+
+		assertFilesExist(blockBaseDir, 'is-letter.ts');
 	});
 });

--- a/sites/docs/src/routes/docs/cli/add/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/add/+page.svelte
@@ -20,13 +20,39 @@
 <p>Include another registry in the blocks list:</p>
 <Snippet command="execute" args={['jsrepo', 'add', '--repo', 'github/ieedan/std']} />
 <SubHeading>Options</SubHeading>
+<OptionDocs name="--watermark">
+	{#snippet description()}
+		Include a watermark at the top of added files. (For non-interactive zero-config adds)
+	{/snippet}
+	{#snippet usage()}
+		<Snippet command="execute" args={['jsrepo', 'add', '--watermark', 'true']} />
+	{/snippet}
+</OptionDocs>
+<OptionDocs name="--tests">
+	{#snippet description()}
+		Include tests along with the blocks when adding them. (For non-interactive zero-config adds)
+	{/snippet}
+	{#snippet usage()}
+		<Snippet command="execute" args={['jsrepo', 'add', '--tests', 'true']} />
+	{/snippet}
+</OptionDocs>
+<OptionDocs name="--formatter">
+	{#snippet description()}
+		Configure the formatter used when adding and updating blocks. (<CodeSpan>prettier</CodeSpan>, <CodeSpan
+			>biome</CodeSpan
+		>) (For non-interactive zero-config adds)
+	{/snippet}
+	{#snippet usage()}
+		<Snippet command="execute" args={['jsrepo', 'add', '--formatter', 'prettier']} />
+	{/snippet}
+</OptionDocs>
 <OptionDocs name="-E, --expand">
 	{#snippet description()}
 		Expands the diff past the limit set by <CodeSpan>--max-unchanged</CodeSpan> so that you can see the
 		entire file.
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'update', '--expand']} />
+		<Snippet command="execute" args={['jsrepo', 'add', '--expand']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="--max-unchanged">
@@ -35,7 +61,7 @@
 		<CodeSpan>default: 3</CodeSpan>
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'update', '--max-unchanged', '10']} />
+		<Snippet command="execute" args={['jsrepo', 'add', '--max-unchanged', '10']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="--repo">

--- a/sites/docs/src/routes/docs/cli/add/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/add/+page.svelte
@@ -40,10 +40,22 @@
 	{#snippet description()}
 		Configure the formatter used when adding and updating blocks. (<CodeSpan>prettier</CodeSpan>, <CodeSpan
 			>biome</CodeSpan
-		>) (For non-interactive zero-config adds)
+		>, <CodeSpan>none</CodeSpan>) (For non-interactive zero-config adds)
 	{/snippet}
 	{#snippet usage()}
 		<Snippet command="execute" args={['jsrepo', 'add', '--formatter', 'prettier']} />
+	{/snippet}
+</OptionDocs>
+<OptionDocs name="--paths">
+	{#snippet description()}
+		Allows you to specify where to install categories. A mirror of the paths functionality in the
+		<CodeSpan>jsrepo.json</CodeSpan> file. (For non-interactive zero-config adds)
+	{/snippet}
+	{#snippet usage()}
+		<Snippet
+			command="execute"
+			args={['jsrepo', 'add', '--paths', 'utils=./src/blocks/utils,ui=./src/blocks/ui']}
+		/>
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="-E, --expand">

--- a/sites/docs/src/routes/docs/cli/auth/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/auth/+page.svelte
@@ -40,7 +40,7 @@
 		Run the current command on the provided directory absolute or relative.
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'update', '--cwd', './sites/docs']} />
+		<Snippet command="execute" args={['jsrepo', 'auth', '--cwd', './sites/docs']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="-h, --help">

--- a/sites/docs/src/routes/docs/cli/build/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/build/+page.svelte
@@ -167,7 +167,7 @@
 		More verbose logging. (May be used to troubleshoot issues)
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'add', '--verbose']} />
+		<Snippet command="execute" args={['jsrepo', 'build', '--verbose']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="--cwd">
@@ -175,7 +175,7 @@
 		Run the current command on the provided directory absolute or relative.
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'add', '--cwd', './sites/docs']} />
+		<Snippet command="execute" args={['jsrepo', 'build', '--cwd', './sites/docs']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="-h, --help">
@@ -183,6 +183,6 @@
 		Help with the command.
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'add', '--help']} />
+		<Snippet command="execute" args={['jsrepo', 'build', '--help']} />
 	{/snippet}
 </OptionDocs>

--- a/sites/docs/src/routes/docs/cli/exec/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/exec/+page.svelte
@@ -61,7 +61,7 @@
 		default branch for a repository or changing a tag into a head or vise versa.
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'add', '--no-cache']} />
+		<Snippet command="execute" args={['jsrepo', 'exec', '--no-cache']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="--verbose">
@@ -69,7 +69,7 @@
 		More verbose logging. (May be used to troubleshoot issues)
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'add', '--verbose']} />
+		<Snippet command="execute" args={['jsrepo', 'exec', '--verbose']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="--cwd">

--- a/sites/docs/src/routes/docs/cli/init/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/init/+page.svelte
@@ -97,7 +97,7 @@
 		default branch for a repository or changing a tag into a head or vise versa.
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'add', '--no-cache']} />
+		<Snippet command="execute" args={['jsrepo', 'init', '--no-cache']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="--cwd">

--- a/sites/docs/src/routes/docs/cli/test/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/test/+page.svelte
@@ -47,7 +47,7 @@
 		default branch for a repository or changing a tag into a head or vise versa.
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'add', '--no-cache']} />
+		<Snippet command="execute" args={['jsrepo', 'test', '--no-cache']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="--verbose">

--- a/sites/docs/src/routes/docs/cli/update/+page.svelte
+++ b/sites/docs/src/routes/docs/cli/update/+page.svelte
@@ -125,7 +125,7 @@
 		default branch for a repository or changing a tag into a head or vise versa.
 	{/snippet}
 	{#snippet usage()}
-		<Snippet command="execute" args={['jsrepo', 'add', '--no-cache']} />
+		<Snippet command="execute" args={['jsrepo', 'update', '--no-cache']} />
 	{/snippet}
 </OptionDocs>
 <OptionDocs name="--verbose">

--- a/sites/docs/static/docs/cli/llms.txt
+++ b/sites/docs/static/docs/cli/llms.txt
@@ -2,7 +2,7 @@
 
 > A CLI to add shared code from remote repositories.
  
-Latest Version: 1.43.0
+Latest Version: 1.46.2
 
 ## Commands
 
@@ -16,6 +16,10 @@ jsrepo add [options] [blocks...]
 ```
 
 #### Options
+- --formatter <choice>: The formatter to use when adding blocks. 
+- --watermark <choice>: Include a watermark at the top of added files. 
+- --tests <choice>: Include tests when adding blocks. 
+- --paths <category=path,category=path>: The paths where categories should be added to your project. 
 - -E, --expand: Expands the diff so you see the entire file. 
 - --max-unchanged <number>: Maximum unchanged lines that will show without being collapsed. (default: 3)
 - --repo <repo>: Repository to download the blocks from. 


### PR DESCRIPTION
From #520 

This was a obvious oversight of mine pretty disappointing. Also never added docs for the new flags. Now you can more easily configure the flags with a true or false value instead of the --no syntax.