### PR TITLE
feat: support binary include files

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export const blockSchema = v.object({
 	directory: v.string(),
 	subdirectory: v.boolean(),
 	files: v.array(v.string()),
+	assets: v.optional(v.array(v.string())),
 	_imports_: v.record(v.string(), v.string()),
 });
 

--- a/src/utils/build/index.ts
+++ b/src/utils/build/index.ts
@@ -187,6 +187,7 @@ export function buildBlocksDirectory(
 				let hasDocs = false;
 
 				const blockFiles: string[] = [];
+				const blockAssets: string[] = [];
 
 				const shouldIncludeFile = createShouldIncludeFile(config);
 
@@ -218,7 +219,7 @@ export function buildBlocksDirectory(
 						}
 
 						if (shouldIncludeFile(relativeToRootDirectory)) {
-							blockFiles.push(relativeFilePath);
+							blockAssets.push(relativeFilePath);
 							continue;
 						}
 
@@ -303,6 +304,7 @@ export function buildBlocksDirectory(
 					subdirectory: true,
 					list: listCategory ? listBlock : false,
 					files: blockFiles,
+					assets: blockAssets,
 					localDependencies: Array.from(localDepsSet.keys()),
 					dependencies: Array.from(depsSet.keys()),
 					devDependencies: Array.from(devDepsSet.keys()),

--- a/src/utils/registry-providers/internal.ts
+++ b/src/utils/registry-providers/internal.ts
@@ -8,6 +8,7 @@ import { TokenManager } from '../token-manager';
 import {
 	azure,
 	bitbucket,
+	fetchBuffer,
 	fetchManifest,
 	fetchRaw,
 	github,
@@ -28,6 +29,19 @@ export async function internalFetchRaw(
 	{ verbose }: { verbose?: (msg: string) => void } = {}
 ) {
 	return await fetchRaw(state, resourcePath, {
+		verbose,
+		// @ts-expect-error it's fine
+		fetch: iFetch,
+		token: getProviderToken(state.provider, state.url),
+	});
+}
+
+export async function internalFetchBuffer(
+	state: RegistryProviderState,
+	resourcePath: string,
+	{ verbose }: { verbose?: (msg: string) => void } = {}
+) {
+	return await fetchBuffer(state, resourcePath, {
 		verbose,
 		// @ts-expect-error it's fine
 		fetch: iFetch,
@@ -250,5 +264,6 @@ export {
 	providers,
 	internalFetchManifest as fetchManifest,
 	internalFetchRaw as fetchRaw,
+	internalFetchBuffer as fetchRawBuffer,
 	selectProvider,
 };


### PR DESCRIPTION
An attempt to fix the issue outlined [here](https://github.com/jsrepojs/jsrepo/discussions/616#discussioncomment-14528068).

After letting it rest for a while, I think I came up with a pragmatic solution.

The following changed.
- During build time, the "includeFiles" are added to the manifest under a different key. This allows us to make the distinction between regular files and these "extra files" when adding the block.
- During add time, the "includeFiles" are fetched using a different method which does not convert the file to text. Rather it converts it into a buffer.
- This buffer is then just written to disk, without any modifications.

I've used the key "assets" for these files in the manifest. In hindsight, I should have probably called the "includeFiles" config option something along these lines as well.

This might need some more consideration. For example, do we want the files to be written in all cases. Maybe A prompt like the regular files is more appropriate.

Would love to get some feedback on this.