### PR TITLE
fix: ensure to create new directories during update

### DIFF
--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,10 +1,10 @@
 import fs from 'node:fs';
-import path from 'node:path';
 import { cancel, confirm, isCancel, multiselect, outro } from '@clack/prompts';
 import color from 'chalk';
 import { Command, program } from 'commander';
 import { resolveCommand } from 'package-manager-detector/commands';
 import { detect } from 'package-manager-detector/detect';
+import path from 'pathe';
 import * as v from 'valibot';
 import * as ascii from '../utils/ascii';
 import { getBlockFilePath, getInstalled, preloadBlocks, resolveTree } from '../utils/blocks';


### PR DESCRIPTION
When updating a block which contains a newly added directory, the writeFileSync errors.