### PR TITLE
fix: Improve error handling by displaying the response.message when it's available

### DIFF
--- a/.changeset/true-ways-heal.md
+++ b/.changeset/true-ways-heal.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+fix: Improve error handling by displaying the response.message when it's available
+  

--- a/src/utils/registry-providers/index.ts
+++ b/src/utils/registry-providers/index.ts
@@ -53,6 +53,17 @@ export async function fetchRaw(
 		verbose?.(`Got a response from ${url} ${response.status} ${response.statusText}`);
 
 		if (!response.ok) {
+			const isJson = response.headers.get('content-type')?.includes('application/json');
+			if (isJson) {
+				const jsonError = await response.json();
+				return Err(
+					state.provider.formatFetchError(
+						state,
+						resourcePath,
+						`${response.status} ${jsonError.message ?? response.statusText}`
+					)
+				);
+			}
 			return Err(
 				state.provider.formatFetchError(
 					state,


### PR DESCRIPTION
This should help give users better errors when trying to use a v3 registry with the v2 CLI.