### PR TITLE
fix: Ensure items in repository mode are fetched with the `relativePath`

### DIFF
--- a/.changeset/tall-pillows-hide.md
+++ b/.changeset/tall-pillows-hide.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+fix: Ensure items in repository mode are fetched with the `relativePath`
+  

--- a/packages/jsrepo/src/utils/add.ts
+++ b/packages/jsrepo/src/utils/add.ts
@@ -393,7 +393,7 @@ async function fetchItemRepositoryMode(
 ): Promise<Result<ItemRepository, RegistryFileFetchError>> {
 	const files = await Promise.all(
 		(item.files as RepositoryOutputFile[]).map(async (file) => {
-			const result = await fetchFile(file.path, item);
+			const result = await fetchFile(file.relativePath, item);
 			if (result.isErr()) return err(result.error);
 			return ok({
 				...file,


### PR DESCRIPTION
Fixes #700 