### PR TITLE
Update docs link extension

### DIFF
--- a/apps/docs/middleware.ts
+++ b/apps/docs/middleware.ts
@@ -2,10 +2,18 @@ import { NextRequest, NextResponse } from "next/server";
 import { isMarkdownPreferred, rewritePath } from "fumadocs-core/negotiation";
 
 const { rewrite: rewriteLLM } = rewritePath("/docs/*path", "/llms.mdx/*path");
+const { rewrite: rewriteLLMMD } = rewritePath("/docs/*path", "/llms.md/*path");
 
 export function middleware(request: NextRequest) {
+	const pathname = request.nextUrl.pathname;
+	
+	// Skip middleware for explicit .mdx and .md URLs - let redirects/rewrites handle them
+	if (pathname.endsWith('.mdx') || pathname.endsWith('.md')) {
+		return NextResponse.next();
+	}
+	
 	if (isMarkdownPreferred(request)) {
-		const result = rewriteLLM(request.nextUrl.pathname);
+		const result = rewriteLLM(pathname);
 
 		if (result) {
 			return NextResponse.rewrite(new URL(result, request.nextUrl));

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,11 +5,24 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const config = {
 	reactStrictMode: true,
+	async redirects() {
+		return [
+			{
+				source: "/docs/:path*.mdx",
+				destination: "/docs/:path*.md",
+				permanent: true,
+			},
+		];
+	},
 	async rewrites() {
 		return [
 			{
 				source: "/docs/:path*.mdx",
 				destination: "/llms.mdx/:path*",
+			},
+			{
+				source: "/docs/:path*.md",
+				destination: "/llms.md/:path*",
 			},
 		];
 	},

--- a/apps/docs/src/app/llms.md/[[...slug]]/route.ts
+++ b/apps/docs/src/app/llms.md/[[...slug]]/route.ts
@@ -1,0 +1,21 @@
+import { getLLMText } from "@/lib/source";
+import { source } from "@/lib/source";
+import { notFound } from "next/navigation";
+
+export const revalidate = false;
+
+export async function GET(_req: Request, { params }: RouteContext<"/llms.md/[[...slug]]">) {
+	const { slug } = await params;
+	const page = source.getPage(slug);
+	if (!page) notFound();
+
+	return new Response(await getLLMText(page), {
+		headers: {
+			"Content-Type": "text/markdown",
+		},
+	});
+}
+
+export function generateStaticParams() {
+	return source.generateParams();
+}


### PR DESCRIPTION
Enable `.md` URLs for documentation and redirect `.mdx` to `.md` to facilitate easier access to markdown content for LLMs.

---
<a href="https://cursor.com/background-agent?bcId=bc-8006439d-5945-4eeb-b080-7d0144295a8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8006439d-5945-4eeb-b080-7d0144295a8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

