### PR TITLE
feat: add `headers` to `http` provider to allow for providing custom headers with every request

### DIFF
--- a/.changeset/pink-baths-post.md
+++ b/.changeset/pink-baths-post.md
@@ -1,0 +1,6 @@
+---
+"jsrepo": patch
+---
+
+feat: add `headers` to `http` provider to allow for providing custom headers with every request
+  

--- a/packages/jsrepo/src/providers/http.ts
+++ b/packages/jsrepo/src/providers/http.ts
@@ -2,7 +2,7 @@ import type { FetchOptions, Provider, ProviderFactory } from '@/providers/types'
 import { ProviderFetchError } from '@/utils/errors';
 import { addTrailingSlash } from '@/utils/url';
 
-export type HttpOptions =
+export type HttpOptions = (
 	| {
 			baseUrl?: never;
 			/**
@@ -20,7 +20,13 @@ export type HttpOptions =
 			baseUrl: string;
 			/** The auth header for your site. */
 			authHeader?: (token: string) => Record<string, string>;
-	  };
+	  }
+) & {
+	/**
+	 * Additional headers to add to the request. The authHeader function result will override these headers.
+	 */
+	headers?: Record<string, string>;
+};
 
 /**
  * The built in http provider. When using this provider you should place it at the end of the providers array otherwise it will match all urls.
@@ -93,6 +99,7 @@ class Http implements Provider {
 		const url = this.resolveRaw(resourcePath);
 		try {
 			const headers: Record<string, string> = {
+				...(this.opts.headers ?? {}),
 				...(this.authHeader(token) ?? {}),
 			};
 

--- a/packages/jsrepo/tests/providers/http.test.ts
+++ b/packages/jsrepo/tests/providers/http.test.ts
@@ -1,14 +1,101 @@
-import { describe, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { http } from '@/providers';
 import type { AbsolutePath } from '@/utils/types';
 
 describe('http', () => {
-	it('correctly resolves repository url', async () => {
+	it('correctly resolves url', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			text: vi.fn().mockResolvedValue('mock content'),
+			headers: new Headers(),
+		});
+
 		const h = http();
-		const httpState = await h.create('https://jsrepo-http.vercel.app', {
+		const httpState = await h.create('https://example.com', {
 			cwd: process.cwd() as AbsolutePath,
 			token: undefined,
 		});
-		await httpState.fetch('jsrepo-manifest.json', { token: undefined });
+
+		await httpState.fetch('jsrepo-manifest.json', {
+			token: undefined,
+			fetch: mockFetch,
+		});
+
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		expect(mockFetch).toHaveBeenCalledWith(
+			'https://example.com/jsrepo-manifest.json',
+			expect.objectContaining({
+				headers: {},
+			})
+		);
+	});
+
+	it('adds custom headers to the request', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			text: vi.fn().mockResolvedValue('mock content'),
+			headers: new Headers(),
+		});
+
+		const h = http({
+			baseUrl: 'https://example.com',
+			headers: {
+				'X-Custom-Header': 'custom value',
+			},
+		});
+		const httpState = await h.create('https://example.com', {
+			cwd: process.cwd() as AbsolutePath,
+			token: undefined,
+		});
+		await httpState.fetch('jsrepo-manifest.json', {
+			token: undefined,
+			fetch: mockFetch,
+		});
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		expect(mockFetch).toHaveBeenCalledWith(
+			'https://example.com/jsrepo-manifest.json',
+			expect.objectContaining({
+				headers: {
+					'X-Custom-Header': 'custom value',
+				},
+			})
+		);
+	});
+
+	it('authHeader overrides base provider headers', async () => {
+		const mockFetch = vi.fn().mockResolvedValue({
+			ok: true,
+			text: vi.fn().mockResolvedValue('mock content'),
+			headers: new Headers(),
+		});
+
+		const h = http({
+			baseUrl: 'https://example.com',
+			headers: {
+				'X-Custom-Header': 'base value',
+				Authorization: 'base-auth-value',
+			},
+			authHeader: (token) => ({
+				Authorization: `Bearer ${token}`,
+			}),
+		});
+		const httpState = await h.create('https://example.com', {
+			cwd: process.cwd() as AbsolutePath,
+			token: undefined,
+		});
+		await httpState.fetch('jsrepo-manifest.json', {
+			token: 'test-token-123',
+			fetch: mockFetch,
+		});
+		expect(mockFetch).toHaveBeenCalledTimes(1);
+		expect(mockFetch).toHaveBeenCalledWith(
+			'https://example.com/jsrepo-manifest.json',
+			expect.objectContaining({
+				headers: {
+					'X-Custom-Header': 'base value',
+					Authorization: 'Bearer test-token-123',
+				},
+			})
+		);
 	});
 });


### PR DESCRIPTION
Fixes #735 